### PR TITLE
fix: comparison involving different types

### DIFF
--- a/include/boost/range/iterator_range_core.hpp
+++ b/include/boost/range/iterator_range_core.hpp
@@ -336,7 +336,7 @@ protected:
 public:
     reference operator[](difference_type at) const
     {
-        BOOST_ASSERT(at >= 0 && at < size());
+      BOOST_ASSERT(at >= difference_type(0) && at < difference_type(size()));
         return this->m_Begin[at];
     }
 
@@ -347,7 +347,7 @@ public:
     //
     abstract_value_type operator()(difference_type at) const
     {
-        BOOST_ASSERT(at >= 0 && at < size());
+        BOOST_ASSERT(at >= difference_type(0) && at < difference_type(size()));
         return this->m_Begin[at];
     }
 


### PR DESCRIPTION
difference_type does not necessary need to be of type int or size_t
