### PR TITLE
Update transform.hpp

### DIFF
--- a/include/boost/range/algorithm/transform.hpp
+++ b/include/boost/range/algorithm/transform.hpp
@@ -58,9 +58,8 @@ namespace boost
                        OutputIterator                       out,
                        BinaryFunction                       fn)
         {
-            for (; first1 != last1; ++first1, ++first2)
+            for (; first1 != last1 && first2 != last2; ++first1, ++first2)
             {
-                BOOST_ASSERT( first2 != last2 );
                 *out = fn(*first1, *first2);
                 ++out;
             }


### PR DESCRIPTION
Ticket #9812 BinaryOperation boost::transform only stops when it reaches the end of rng1, even if rng2 is shorter

The docs for binary transform indicate that iteration should stop when either range reaches its end. However, the original implementation only stops when rng1 is finished, and asserts if rng2 reaches its end before rng1. I modified the transform to stop when either rng is exhausted. This behavior matches the existing documentation.

This is my first pull request, so I'm learning. Please give constructive suggestions if there are parts of the process I'm missing or things I can do to make the process smoother.

Thanks,
David
