### PR TITLE
[doc] Fix typo in the name of forward traversal tag.

### DIFF
--- a/doc/reference/ranges/any_range.qbk
+++ b/doc/reference/ranges/any_range.qbk
@@ -7,7 +7,7 @@
 
 [heading Description]
 
-`any_range` is a range that has the type information erased hence a `any_range<int, boost::forward_pass_traversal_tag, int, std::ptrdiff_t>`
+`any_range` is a range that has the type information erased hence a `any_range<int, boost::forward_traversal_tag, int, std::ptrdiff_t>`
 can be used to represent a `std::vector<int>`, a `std::list<int>` or many other types.
 
 The __type_erasure_article__ covers the motivation and goals of type erasure in this context. Clearly


### PR DESCRIPTION
Fix typo in the name of forward traversal tag.
