### PR TITLE
more robust implementation for BOOST_RANGE_EXTRACT_OPTIONAL_TYPE

### DIFF
--- a/include/boost/range/detail/extract_optional_type.hpp
+++ b/include/boost/range/detail/extract_optional_type.hpp
@@ -15,36 +15,32 @@
 #endif
 
 #include <boost/config.hpp>
+#include <boost/preprocessor/cat.hpp>
+#include <boost/mpl/has_xxx.hpp>
 
-#ifdef BOOST_NO_PARTIAL_SPECIALIZATION_IMPLICIT_DEFAULT_ARGS
-
-#define BOOST_RANGE_EXTRACT_OPTIONAL_TYPE( a_typedef )                         \
-    template< typename C >                                                     \
-    struct extract_ ## a_typedef                                               \
-    {                                                                          \
-        typedef BOOST_DEDUCED_TYPENAME C::a_typedef type;                      \
-    };
-
-#else
-
-namespace boost {
-    namespace range_detail {
-        template< typename T > struct exists { typedef void type; };
-    }
-}
+#if !defined(BOOST_MPL_CFG_NO_HAS_XXX)
 
 // Defines extract_some_typedef<T> which exposes T::some_typedef as
 // extract_some_typedef<T>::type if T::some_typedef exists. Otherwise
 // extract_some_typedef<T> is empty.
-#define BOOST_RANGE_EXTRACT_OPTIONAL_TYPE( a_typedef )                         \
-    template< typename C, typename Enable=void >                               \
-    struct extract_ ## a_typedef                                               \
-    {};                                                                        \
-    template< typename C >                                                     \
-    struct extract_ ## a_typedef< C                                            \
-    , BOOST_DEDUCED_TYPENAME boost::range_detail::exists< BOOST_DEDUCED_TYPENAME C::a_typedef >::type \
-    > {                                                                        \
-        typedef BOOST_DEDUCED_TYPENAME C::a_typedef type;                      \
+#define BOOST_RANGE_EXTRACT_OPTIONAL_TYPE( a_typedef )                          \
+    BOOST_MPL_HAS_XXX_TRAIT_DEF(a_typedef)                                      \
+    template< typename  C, bool B = BOOST_PP_CAT(has_, a_typedef)<C>::value >   \
+    struct BOOST_PP_CAT(extract_, a_typedef)                                    \
+    {};                                                                         \
+    template< typename C >                                                      \
+    struct BOOST_PP_CAT(extract_, a_typedef)< C, true >                         \
+    {                                                                           \
+        typedef BOOST_DEDUCED_TYPENAME C::a_typedef type;                       \
+    };
+
+#else
+
+#define BOOST_RANGE_EXTRACT_OPTIONAL_TYPE( a_typedef )                          \
+    template< typename C >                                                      \
+    struct BOOST_PP_CAT(extract_, a_typedef)                                    \
+    {                                                                           \
+        typedef BOOST_DEDUCED_TYPENAME C::a_typedef type;                       \
     };
 
 #endif


### PR DESCRIPTION
I wonder if you'd be willing to accept this more robust implementation for the `BOOST_RANGE_EXTRACT_OPTIONAL_TYPE` macro? I've had random failures on MSVC with the current implementation is situations where I get a hard error instead of SFINAE in the defaulted template parameter. Thanks.
