### PR TITLE
Accommodate the latest changes in Boost.Iterator.

### DIFF
--- a/include/boost/range/detail/any_iterator.hpp
+++ b/include/boost/range/detail/any_iterator.hpp
@@ -114,139 +114,140 @@ namespace boost
         };
     } // namespace range_detail
 
-    namespace detail
+    namespace iterators
     {
-        // Rationale:
-        // These are specialized since the iterator_facade versions lack
-        // the requisite typedefs to allow wrapping to determine the types
-        // if a user copy constructs from a postfix increment.
-
-        template<
-            class Value
-          , class Traversal
-          , class Reference
-          , class Difference
-          , class Buffer
-        >
-        class postfix_increment_proxy<
-                    range_detail::any_iterator<
-                        Value
-                      , Traversal
-                      , Reference
-                      , Difference
-                      , Buffer
-                    >
-                >
+        namespace detail
         {
-            typedef range_detail::any_iterator<
-                Value
-              , Traversal
-              , Reference
-              , Difference
-              , Buffer
-            > any_iterator_type;
+            // Rationale:
+            // These are specialized since the iterator_facade versions lack
+            // the requisite typedefs to allow wrapping to determine the types
+            // if a user copy constructs from a postfix increment.
 
-        public:
-            typedef Value value_type;
-            typedef typename std::iterator_traits<any_iterator_type>::iterator_category iterator_category;
-            typedef Difference difference_type;
-            typedef typename iterator_pointer<any_iterator_type>::type pointer;
-            typedef Reference reference;
-
-            explicit postfix_increment_proxy(any_iterator_type const& x)
-                : stored_value(*x)
-            {}
-
-            value_type&
-            operator*() const
-            {
-                return this->stored_value;
-            }
-        private:
-            mutable value_type stored_value;
-        };
-
-        template<
-            class Value
-          , class Traversal
-          , class Reference
-          , class Difference
-          , class Buffer
-        >
-        class writable_postfix_increment_proxy<
-                    range_detail::any_iterator<
-                        Value
-                      , Traversal
-                      , Reference
-                      , Difference
-                      , Buffer
+            template<
+                class Value
+              , class Traversal
+              , class Reference
+              , class Difference
+              , class Buffer
+            >
+            class postfix_increment_proxy<
+                        range_detail::any_iterator<
+                            Value
+                          , Traversal
+                          , Reference
+                          , Difference
+                          , Buffer
+                        >
                     >
-                >
-        {
-            typedef range_detail::any_iterator<
-                        Value
-                      , Traversal
-                      , Reference
-                      , Difference
-                      , Buffer
-                    > any_iterator_type;
-         public:
-            typedef Value value_type;
-            typedef typename std::iterator_traits<any_iterator_type>::iterator_category iterator_category;
-            typedef Difference difference_type;
-            typedef typename iterator_pointer<any_iterator_type>::type pointer;
-            typedef Reference reference;
-
-            explicit writable_postfix_increment_proxy(any_iterator_type const& x)
-              : stored_value(*x)
-              , stored_iterator(x)
-            {}
-
-            // Dereferencing must return a proxy so that both *r++ = o and
-            // value_type(*r++) can work.  In this case, *r is the same as
-            // *r++, and the conversion operator below is used to ensure
-            // readability.
-            writable_postfix_increment_proxy const&
-            operator*() const
             {
-                return *this;
-            }
+                typedef range_detail::any_iterator<
+                    Value
+                  , Traversal
+                  , Reference
+                  , Difference
+                  , Buffer
+                > any_iterator_type;
 
-            // Provides readability of *r++
-            operator value_type&() const
+            public:
+                typedef Value value_type;
+                typedef typename std::iterator_traits<any_iterator_type>::iterator_category iterator_category;
+                typedef Difference difference_type;
+                typedef typename iterator_pointer<any_iterator_type>::type pointer;
+                typedef Reference reference;
+
+                explicit postfix_increment_proxy(any_iterator_type const& x)
+                    : stored_value(*x)
+                {}
+
+                value_type&
+                operator*() const
+                {
+                    return this->stored_value;
+                }
+            private:
+                mutable value_type stored_value;
+            };
+
+            template<
+                class Value
+              , class Traversal
+              , class Reference
+              , class Difference
+              , class Buffer
+            >
+            class writable_postfix_increment_proxy<
+                        range_detail::any_iterator<
+                            Value
+                          , Traversal
+                          , Reference
+                          , Difference
+                          , Buffer
+                        >
+                    >
             {
-                return stored_value;
-            }
+                typedef range_detail::any_iterator<
+                            Value
+                          , Traversal
+                          , Reference
+                          , Difference
+                          , Buffer
+                        > any_iterator_type;
+            public:
+                typedef Value value_type;
+                typedef typename std::iterator_traits<any_iterator_type>::iterator_category iterator_category;
+                typedef Difference difference_type;
+                typedef typename iterator_pointer<any_iterator_type>::type pointer;
+                typedef Reference reference;
 
-            // Provides writability of *r++
-            template <class T>
-            T const& operator=(T const& x) const
-            {
-                *this->stored_iterator = x;
-                return x;
-            }
+                explicit writable_postfix_increment_proxy(any_iterator_type const& x)
+                  : stored_value(*x)
+                  , stored_iterator(x)
+                {}
 
-            // This overload just in case only non-const objects are writable
-            template <class T>
-            T& operator=(T& x) const
-            {
-                *this->stored_iterator = x;
-                return x;
-            }
+                // Dereferencing must return a proxy so that both *r++ = o and
+                // value_type(*r++) can work.  In this case, *r is the same as
+                // *r++, and the conversion operator below is used to ensure
+                // readability.
+                writable_postfix_increment_proxy const&
+                operator*() const
+                {
+                    return *this;
+                }
 
-            // Provides X(r++)
-            operator any_iterator_type const&() const
-            {
-                return stored_iterator;
-            }
+                // Provides readability of *r++
+                operator value_type&() const
+                {
+                    return stored_value;
+                }
 
-         private:
-            mutable value_type stored_value;
-            any_iterator_type stored_iterator;
-        };
+                // Provides writability of *r++
+                template <class T>
+                T const& operator=(T const& x) const
+                {
+                    *this->stored_iterator = x;
+                    return x;
+                }
 
+                // This overload just in case only non-const objects are writable
+                template <class T>
+                T& operator=(T& x) const
+                {
+                    *this->stored_iterator = x;
+                    return x;
+                }
 
-    }
+                // Provides X(r++)
+                operator any_iterator_type const&() const
+                {
+                    return stored_iterator;
+                }
+
+            private:
+                mutable value_type stored_value;
+                any_iterator_type stored_iterator;
+            };
+        } // namespace detail
+    } // namespace iterators
 
     namespace range_detail
     {

--- a/include/boost/range/detail/demote_iterator_traversal_tag.hpp
+++ b/include/boost/range/detail/demote_iterator_traversal_tag.hpp
@@ -79,8 +79,8 @@ BOOST_DEMOTE_TRAVERSAL_TAG( random_access_traversal_tag, random_access_traversal
 template<class IteratorTraversalTag1, class IteratorTraversalTag2>
 struct demote_iterator_traversal_tag
     : inner_demote_iterator_traversal_tag<
-        typename boost::detail::pure_traversal_tag< IteratorTraversalTag1 >::type,
-        typename boost::detail::pure_traversal_tag< IteratorTraversalTag2 >::type
+        typename boost::iterators::pure_traversal_tag< IteratorTraversalTag1 >::type,
+        typename boost::iterators::pure_traversal_tag< IteratorTraversalTag2 >::type
       >
 {
 };


### PR DESCRIPTION
In pull request https://github.com/boostorg/iterator/pull/5 most implementation details were moved to the boost::iterators and boost::iterators::detail namespaces. This pull request updates Boost.Range to reflect these changes.

The pull request partially depends on another pull request https://github.com/boostorg/iterator/pull/6 which makes pure_traversal_tag a public component and not an implementation detail.
