### PR TITLE
accomodate new boost::iterators namespace.

### DIFF
--- a/include/boost/range/detail/any_iterator.hpp
+++ b/include/boost/range/detail/any_iterator.hpp
@@ -114,6 +114,8 @@ namespace boost
         };
     } // namespace range_detail
 
+    namespace iterators
+    {
     namespace detail
     {
         // Rationale:
@@ -246,6 +248,7 @@ namespace boost
         };
 
 
+    }
     }
 
     namespace range_detail

--- a/include/boost/range/detail/demote_iterator_traversal_tag.hpp
+++ b/include/boost/range/detail/demote_iterator_traversal_tag.hpp
@@ -79,8 +79,8 @@ BOOST_DEMOTE_TRAVERSAL_TAG( random_access_traversal_tag, random_access_traversal
 template<class IteratorTraversalTag1, class IteratorTraversalTag2>
 struct demote_iterator_traversal_tag
     : inner_demote_iterator_traversal_tag<
-        typename boost::detail::pure_traversal_tag< IteratorTraversalTag1 >::type,
-        typename boost::detail::pure_traversal_tag< IteratorTraversalTag2 >::type
+        typename boost::iterators::detail::pure_traversal_tag< IteratorTraversalTag1 >::type,
+        typename boost::iterators::detail::pure_traversal_tag< IteratorTraversalTag2 >::type
       >
 {
 };


### PR DESCRIPTION
See boostorg/iterator@dc96d371faf87a88c04057861136c9dfa68103d7
