### PR TITLE
Use public interface of Boost.Iterator

### DIFF
--- a/include/boost/range/detail/demote_iterator_traversal_tag.hpp
+++ b/include/boost/range/detail/demote_iterator_traversal_tag.hpp
@@ -79,8 +79,8 @@ BOOST_DEMOTE_TRAVERSAL_TAG( random_access_traversal_tag, random_access_traversal
 template<class IteratorTraversalTag1, class IteratorTraversalTag2>
 struct demote_iterator_traversal_tag
     : inner_demote_iterator_traversal_tag<
-        typename boost::iterators::detail::pure_traversal_tag< IteratorTraversalTag1 >::type,
-        typename boost::iterators::detail::pure_traversal_tag< IteratorTraversalTag2 >::type
+        typename boost::iterators::pure_traversal_tag< IteratorTraversalTag1 >::type,
+        typename boost::iterators::pure_traversal_tag< IteratorTraversalTag2 >::type
       >
 {
 };


### PR DESCRIPTION
The pull request accommodates changes to Boost.Iterator and switch to the public interface instead of implementation details.