### PR TITLE
fix ticket #10754

### DIFF
--- a/include/boost/range/detail/any_iterator.hpp
+++ b/include/boost/range/detail/any_iterator.hpp
@@ -114,6 +114,7 @@ namespace boost
         };
     } // namespace range_detail
 
+    namespace iterators {
     namespace detail
     {
         // Rationale:
@@ -245,8 +246,8 @@ namespace boost
             any_iterator_type stored_iterator;
         };
 
-
-    }
+    } //namespace detail
+    } //namespace iterators
 
     namespace range_detail
     {


### PR DESCRIPTION
as described in https://svn.boost.org/trac/boost/ticket/10754, postfix_increment_proxy and writable_postfix_increment_proxy were moved to boost::iterators::detail namespace in boost/iterator/iterator_facade.hpp