### PR TITLE
fix missing return statement

### DIFF
--- a/include/boost/range/algorithm_ext/insert.hpp
+++ b/include/boost/range/algorithm_ext/insert.hpp
@@ -39,6 +39,7 @@ inline Container& insert( Container& on, const Range& from )
     BOOST_RANGE_CONCEPT_ASSERT(( ForwardRangeConcept<Container> ));
     BOOST_RANGE_CONCEPT_ASSERT(( SinglePassRangeConcept<Range> ));
     on.insert(boost::begin(from), boost::end(from));
+    return on;
 }
 
     } // namespace range


### PR DESCRIPTION
boost::insert( Container&, const Range&) does not return anything;
It conflicts with return type.