### PR TITLE
fix build break on msvc-8.0

### DIFF
--- a/include/boost/range/difference_type.hpp
+++ b/include/boost/range/difference_type.hpp
@@ -26,17 +26,12 @@ namespace boost
 {
     namespace range_detail
     {
-        template< class T, class Enabler=void >
+        template< class T, bool B = has_type<range_iterator<T> >::value >
         struct range_difference
         { };
 
         template< class T >
-        struct range_difference<
-            T,
-            BOOST_DEDUCED_TYPENAME ::boost::enable_if_c<
-                has_type<range_iterator<T> >::value
-            >::type
-        >
+        struct range_difference<T, true>
           : iterator_difference<
                 BOOST_DEDUCED_TYPENAME range_iterator<T>::type
             >

--- a/include/boost/range/size.hpp
+++ b/include/boost/range/size.hpp
@@ -54,11 +54,20 @@ namespace boost
     inline typename range_size<const SinglePassRange>::type
     size(const SinglePassRange& rng)
     {
+// Very strange things happen on some compilers that have the range concept
+// asserts disabled. This preprocessor condition is clearly redundant on a
+// working compiler but is vital for at least some compilers such as clang 4.2
+// but only on the Mac!
+#if BOOST_RANGE_ENABLE_CONCEPT_ASSERT == 1
+        BOOST_RANGE_CONCEPT_ASSERT((boost::SinglePassRangeConcept<SinglePassRange>));
+#endif
+
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
     !BOOST_WORKAROUND(__GNUC__, < 3) \
     /**/
         using namespace range_detail;
 #endif
+
         return range_calculate_size(rng);
     }
 

--- a/include/boost/range/size_type.hpp
+++ b/include/boost/range/size_type.hpp
@@ -68,27 +68,14 @@ namespace boost
             typedef BOOST_DEDUCED_TYPENAME C::size_type type;
         };
 
-        template<typename C, typename Enabler=void>
+        template<typename C, bool B = range_detail::has_type< range_iterator<C> >::value>
         struct range_size
         { };
 
         template<typename C>
-        struct range_size<
-            C,
-            BOOST_DEDUCED_TYPENAME ::boost::enable_if_c<
-                range_detail::has_type< range_iterator<C> >::value
-            >::type
-        >
+        struct range_size<C, true>
           : range_size_<C>
-        {
-// Very strange things happen on some compilers that have the range concept
-// asserts disabled. This preprocessor condition is clearly redundant on a
-// working compiler but is vital for at least some compilers such as clang 4.2
-// but only on the Mac!
-#if BOOST_RANGE_ENABLE_CONCEPT_ASSERT == 1
-            BOOST_RANGE_CONCEPT_ASSERT((boost::SinglePassRangeConcept<C>));
-#endif
-        };
+        { };
     }
 
     template< class T >

--- a/include/boost/range/sub_range.hpp
+++ b/include/boost/range/sub_range.hpp
@@ -182,8 +182,8 @@ public:
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1500) ) 
         sub_range(const sub_range& r)
-            : base(impl::adl_begin(static_cast<const base&>(r)),
-                   impl::adl_end(static_cast<const base&>(r)))
+            : base(impl::adl_begin(const_cast<base&>(static_cast<const base&>(r))),
+                   impl::adl_end(const_cast<base&>(static_cast<const base&>(r))))
         { }  
 #endif
 


### PR DESCRIPTION
811b271 caused failures on msvc-8.0. This restores order. It also includes a drive-by fix to a bad hack in sub_range.hpp for msvc. I have no idea how this was ever compiling.