### PR TITLE
Use operator || rather than boost::mpl::or_ for constant boolean exprtession.

### DIFF
--- a/include/boost/range/detail/common.hpp
+++ b/include/boost/range/detail/common.hpp
@@ -18,10 +18,8 @@
 #include <boost/range/config.hpp>
 #include <boost/range/detail/sfinae.hpp>
 #include <boost/type_traits/is_void.hpp>
-#include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/int.hpp>
-#include <boost/mpl/or.hpp>
 #include <cstddef>
 
 //////////////////////////////////////////////////////////////////////////////
@@ -71,7 +69,7 @@ namespace boost
             BOOST_STATIC_CONSTANT( bool, is_const_wchar_t_ptr_   = sizeof( boost::range_detail::is_const_wchar_t_ptr_impl( ptr ) ) == sizeof( yes_type ) );
             BOOST_STATIC_CONSTANT( bool, is_char_array_          = sizeof( boost::range_detail::is_char_array_impl( ptr ) ) == sizeof( yes_type ) );
             BOOST_STATIC_CONSTANT( bool, is_wchar_t_array_       = sizeof( boost::range_detail::is_wchar_t_array_impl( ptr ) ) == sizeof( yes_type ) );
-            BOOST_STATIC_CONSTANT( bool, is_string_              = (boost::mpl::or_<boost::mpl::bool_<is_const_char_ptr_>, boost::mpl::bool_<is_const_wchar_t_ptr_> >::value ));
+            BOOST_STATIC_CONSTANT( bool, is_string_              = (is_const_char_ptr_ || is_const_wchar_t_ptr_);
             BOOST_STATIC_CONSTANT( bool, is_array_               = boost::is_array<C>::value );
             
         };

--- a/include/boost/range/detail/common.hpp
+++ b/include/boost/range/detail/common.hpp
@@ -69,7 +69,7 @@ namespace boost
             BOOST_STATIC_CONSTANT( bool, is_const_wchar_t_ptr_   = sizeof( boost::range_detail::is_const_wchar_t_ptr_impl( ptr ) ) == sizeof( yes_type ) );
             BOOST_STATIC_CONSTANT( bool, is_char_array_          = sizeof( boost::range_detail::is_char_array_impl( ptr ) ) == sizeof( yes_type ) );
             BOOST_STATIC_CONSTANT( bool, is_wchar_t_array_       = sizeof( boost::range_detail::is_wchar_t_array_impl( ptr ) ) == sizeof( yes_type ) );
-            BOOST_STATIC_CONSTANT( bool, is_string_              = (is_const_char_ptr_ || is_const_wchar_t_ptr_);
+            BOOST_STATIC_CONSTANT( bool, is_string_              = (is_const_char_ptr_ || is_const_wchar_t_ptr_));
             BOOST_STATIC_CONSTANT( bool, is_array_               = boost::is_array<C>::value );
             
         };


### PR DESCRIPTION
Change for code replacing use of deprecated type_traits headers.