### PR TITLE
Add char16_t and char32_t to the list of literal string types. Fixes …

### DIFF
--- a/include/boost/range/as_literal.hpp
+++ b/include/boost/range/as_literal.hpp
@@ -25,6 +25,11 @@
 #include <boost/detail/workaround.hpp>
 
 #include <cstring>
+
+#if !defined(BOOST_NO_CHAR16_T) || !defined(BOOST_NO_CHAR32_T)
+#include <string>  // for std::char_traits
+#endif
+
 #ifndef BOOST_NO_CWCHAR
 #include <cwchar>
 #endif
@@ -37,6 +42,20 @@ namespace boost
         {
             return strlen( s );
         }
+
+#ifndef BOOST_NO_CHAR16_T
+        inline std::size_t length( const char16_t* s )
+        {
+            return std::char_traits<char16_t>::length( s );
+        }
+#endif
+
+#ifndef BOOST_NO_CHAR32_T
+        inline std::size_t length( const char32_t* s )
+        {
+            return std::char_traits<char32_t>::length( s );
+        }
+#endif
 
 #ifndef BOOST_NO_CWCHAR
         inline std::size_t length( const wchar_t* s )
@@ -60,6 +79,30 @@ namespace boost
         {
             return true;
         }
+
+#ifndef BOOST_NO_CHAR16_T
+        inline bool is_char_ptr( char16_t* )
+        {
+            return true;
+        }
+
+        inline bool is_char_ptr( const char16_t* )
+        {
+            return true;
+        }
+#endif
+
+#ifndef BOOST_NO_CHAR32_T
+        inline bool is_char_ptr( char32_t* )
+        {
+            return true;
+        }
+
+        inline bool is_char_ptr( const char32_t* )
+        {
+            return true;
+        }
+#endif
 
 #ifndef BOOST_NO_CWCHAR
         inline bool is_char_ptr( wchar_t* )


### PR DESCRIPTION
Fix https://svn.boost.org/trac/boost/ticket/11265 by making `char16_t *` and `char32_t *` literal string types.