### PR TITLE
Ticket #10397 - compilation error with mfc-iteratior-support: ambiguous symbol

### DIFF
--- a/include/boost/range/const_iterator.hpp
+++ b/include/boost/range/const_iterator.hpp
@@ -36,7 +36,7 @@ namespace boost
 BOOST_RANGE_EXTRACT_OPTIONAL_TYPE( const_iterator )
 
 template< typename C >
-struct range_const_iterator
+struct range_const_iterator_helper
         : extract_const_iterator<C>
 {};
 
@@ -45,7 +45,7 @@ struct range_const_iterator
 //////////////////////////////////////////////////////////////////////////
 
 template< typename Iterator >
-struct range_const_iterator<std::pair<Iterator,Iterator> >
+struct range_const_iterator_helper<std::pair<Iterator,Iterator> >
 {
     typedef Iterator type;
 };
@@ -55,7 +55,7 @@ struct range_const_iterator<std::pair<Iterator,Iterator> >
 //////////////////////////////////////////////////////////////////////////
 
 template< typename T, std::size_t sz >
-struct range_const_iterator< T[sz] >
+struct range_const_iterator_helper< T[sz] >
 {
     typedef const T* type;
 };
@@ -64,7 +64,7 @@ struct range_const_iterator< T[sz] >
 
 template<typename C, typename Enabler=void>
 struct range_const_iterator
-        : range_detail::range_const_iterator<
+        : range_detail::range_const_iterator_helper<
             BOOST_DEDUCED_TYPENAME remove_reference<C>::type
         >
 {


### PR DESCRIPTION
fixed compilation error for mfc-iteration-support

changed
boost::range_detail::range_const_iterator
to
boost::range_detail::range_const_iterator_helper

to address compilation error when using mfc-iteration-support