### PR TITLE
Added BOOST_CONSTEXPR for begin()/end()

### DIFF
--- a/include/boost/range/begin.hpp
+++ b/include/boost/range/begin.hpp
@@ -36,7 +36,7 @@ namespace range_detail
     //////////////////////////////////////////////////////////////////////
 
     template< typename C >
-    inline BOOST_DEDUCED_TYPENAME range_iterator<C>::type
+    BOOST_CONSTEXPR inline BOOST_DEDUCED_TYPENAME range_iterator<C>::type
     range_begin( C& c )
     {
         //
@@ -52,13 +52,13 @@ namespace range_detail
     //////////////////////////////////////////////////////////////////////
 
     template< typename Iterator >
-    inline Iterator range_begin( const std::pair<Iterator,Iterator>& p )
+    BOOST_CONSTEXPR inline Iterator range_begin( const std::pair<Iterator,Iterator>& p )
     {
         return p.first;
     }
 
     template< typename Iterator >
-    inline Iterator range_begin( std::pair<Iterator,Iterator>& p )
+    BOOST_CONSTEXPR inline Iterator range_begin( std::pair<Iterator,Iterator>& p )
     {
         return p.first;
     }
@@ -71,13 +71,13 @@ namespace range_detail
     // May this be discarded? Or is it needed for bad compilers?
     //
     template< typename T, std::size_t sz >
-    inline const T* range_begin( const T (&a)[sz] )
+    BOOST_CONSTEXPR inline const T* range_begin( const T (&a)[sz] ) BOOST_NOEXCEPT
     {
         return a;
     }
 
     template< typename T, std::size_t sz >
-    inline T* range_begin( T (&a)[sz] )
+    BOOST_CONSTEXPR inline T* range_begin( T (&a)[sz] ) BOOST_NOEXCEPT
     {
         return a;
     }
@@ -94,7 +94,7 @@ namespace range_adl_barrier
 {
 
 template< class T >
-inline BOOST_DEDUCED_TYPENAME range_iterator<T>::type begin( T& r )
+BOOST_CONSTEXPR inline BOOST_DEDUCED_TYPENAME range_iterator<T>::type begin( T& r )
 {
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     using namespace range_detail;
@@ -103,7 +103,7 @@ inline BOOST_DEDUCED_TYPENAME range_iterator<T>::type begin( T& r )
 }
 
 template< class T >
-inline BOOST_DEDUCED_TYPENAME range_iterator<const T>::type begin( const T& r )
+BOOST_CONSTEXPR inline BOOST_DEDUCED_TYPENAME range_iterator<const T>::type begin( const T& r )
 {
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     using namespace range_detail;

--- a/include/boost/range/detail/begin.hpp
+++ b/include/boost/range/detail/begin.hpp
@@ -32,7 +32,7 @@ namespace boost
         struct range_begin<std_container_>
         {
             template< typename C >
-            static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type fun( C& c )
+            BOOST_CONSTEXPR static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type fun( C& c )
             {
                 return c.begin();
             };
@@ -46,7 +46,7 @@ namespace boost
         struct range_begin<std_pair_>
         {
             template< typename P >
-            static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<P>::type fun( const P& p )
+            BOOST_CONSTEXPR static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<P>::type fun( const P& p )
             {
                 return p.first;
             }
@@ -60,7 +60,7 @@ namespace boost
         struct range_begin<array_>
         {
             template<typename T>
-            static BOOST_RANGE_DEDUCED_TYPENAME range_value<T>::type* fun(T& t)
+            BOOST_CONSTEXPR static BOOST_RANGE_DEDUCED_TYPENAME range_value<T>::type* fun(T& t)
             {
                 return t;
             }
@@ -71,7 +71,7 @@ namespace boost
     namespace range_adl_barrier
     {
         template< typename C >
-        inline BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type
+        BOOST_CONSTEXPR inline BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type
         begin( C& c )
         {
             return range_detail::range_begin< BOOST_RANGE_DEDUCED_TYPENAME range_detail::range<C>::type >::fun( c );

--- a/include/boost/range/detail/end.hpp
+++ b/include/boost/range/detail/end.hpp
@@ -33,7 +33,7 @@ namespace boost
         struct range_end<std_container_>
         {
             template< typename C >
-            static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type
+            BOOST_CONSTEXPR static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type
             fun( C& c )
             {
                 return c.end();
@@ -48,7 +48,7 @@ namespace boost
         struct range_end<std_pair_>
         {
             template< typename P >
-            static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<P>::type
+            BOOST_CONSTEXPR static BOOST_RANGE_DEDUCED_TYPENAME range_iterator<P>::type
             fun( const P& p )
             {
                 return p.second;
@@ -63,7 +63,7 @@ namespace boost
         struct range_end<array_>
         {
             template<typename T>
-            static BOOST_RANGE_DEDUCED_TYPENAME remove_extent<T>::type* fun(T& t)
+            BOOST_CONSTEXPR static BOOST_RANGE_DEDUCED_TYPENAME remove_extent<T>::type* fun(T& t)
             {
                 return t + remove_extent<T>::size;
             }
@@ -74,7 +74,7 @@ namespace boost
     namespace range_adl_barrier
     {
         template< typename C >
-        inline BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type
+        BOOST_CONSTEXPR inline BOOST_RANGE_DEDUCED_TYPENAME range_iterator<C>::type
         end( C& c )
         {
             return range_detail::range_end< BOOST_RANGE_DEDUCED_TYPENAME range_detail::range<C>::type >::fun( c );

--- a/include/boost/range/detail/implementation_help.hpp
+++ b/include/boost/range/detail/implementation_help.hpp
@@ -60,13 +60,13 @@ namespace boost
         }
 
         template< class T, std::size_t sz >
-        inline T* array_end( T BOOST_RANGE_ARRAY_REF()[sz] )
+        BOOST_CONSTEXPR inline T* array_end( T BOOST_RANGE_ARRAY_REF()[sz] ) BOOST_NOEXCEPT
         {
             return boost_range_array + sz;
         }
 
         template< class T, std::size_t sz >
-        inline const T* array_end( const T BOOST_RANGE_ARRAY_REF()[sz] )
+        BOOST_CONSTEXPR inline const T* array_end( const T BOOST_RANGE_ARRAY_REF()[sz] ) BOOST_NOEXCEPT
         {
             return boost_range_array + sz;
         }

--- a/include/boost/range/end.hpp
+++ b/include/boost/range/end.hpp
@@ -37,7 +37,7 @@ namespace range_detail
         // primary template
         //////////////////////////////////////////////////////////////////////
         template< typename C >
-        inline BOOST_DEDUCED_TYPENAME range_iterator<C>::type
+        BOOST_CONSTEXPR inline BOOST_DEDUCED_TYPENAME range_iterator<C>::type
         range_end( C& c )
         {
             //
@@ -53,13 +53,13 @@ namespace range_detail
         //////////////////////////////////////////////////////////////////////
 
         template< typename Iterator >
-        inline Iterator range_end( const std::pair<Iterator,Iterator>& p )
+        BOOST_CONSTEXPR inline Iterator range_end( const std::pair<Iterator,Iterator>& p )
         {
             return p.second;
         }
 
         template< typename Iterator >
-        inline Iterator range_end( std::pair<Iterator,Iterator>& p )
+        BOOST_CONSTEXPR inline Iterator range_end( std::pair<Iterator,Iterator>& p )
         {
             return p.second;
         }
@@ -69,13 +69,13 @@ namespace range_detail
         //////////////////////////////////////////////////////////////////////
 
         template< typename T, std::size_t sz >
-        inline const T* range_end( const T (&a)[sz] )
+        BOOST_CONSTEXPR inline const T* range_end( const T (&a)[sz] ) BOOST_NOEXCEPT
         {
             return range_detail::array_end<T,sz>( a );
         }
 
         template< typename T, std::size_t sz >
-        inline T* range_end( T (&a)[sz] )
+        BOOST_CONSTEXPR inline T* range_end( T (&a)[sz] ) BOOST_NOEXCEPT
         {
             return range_detail::array_end<T,sz>( a );
         }
@@ -88,7 +88,7 @@ namespace range_adl_barrier
 {
 
 template< class T >
-inline BOOST_DEDUCED_TYPENAME range_iterator<T>::type end( T& r )
+BOOST_CONSTEXPR inline BOOST_DEDUCED_TYPENAME range_iterator<T>::type end( T& r )
 {
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     using namespace range_detail;
@@ -97,7 +97,7 @@ inline BOOST_DEDUCED_TYPENAME range_iterator<T>::type end( T& r )
 }
 
 template< class T >
-inline BOOST_DEDUCED_TYPENAME range_iterator<const T>::type end( const T& r )
+BOOST_CONSTEXPR inline BOOST_DEDUCED_TYPENAME range_iterator<const T>::type end( const T& r )
 {
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     using namespace range_detail;
@@ -115,7 +115,7 @@ namespace boost
     namespace range_adl_barrier
     {
         template< class T >
-        inline BOOST_DEDUCED_TYPENAME range_iterator<const T>::type
+        BOOST_CONSTEXPR inline BOOST_DEDUCED_TYPENAME range_iterator<const T>::type
         const_end( const T& r )
         {
             return boost::range_adl_barrier::end( r );


### PR DESCRIPTION
Attempt to implement some parts of [P0031R0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0031r0.html) in Boost.
