### PR TITLE
Update irange.hpp

### DIFF
--- a/include/boost/range/irange.hpp
+++ b/include/boost/range/irange.hpp
@@ -205,6 +205,22 @@ namespace boost
 
     template<typename Integer>
     integer_range<Integer>
+    irange(int last)
+    {
+        BOOST_ASSERT( 0 <= last );
+        return integer_range<Integer>(0, last);
+    }
+
+    template<typename Integer>
+    integer_range<Integer>
+    irange(int first, int last)
+    {
+        BOOST_ASSERT( first <= last );
+        return integer_range<Integer>(first, last);
+    }
+
+    template<typename Integer>
+    integer_range<Integer>
     irange(Integer first, Integer last)
     {
         BOOST_ASSERT( first <= last );


### PR DESCRIPTION
Added: irange(int last), irange(int first, int last)
They are useful for some quick iteration. 

irange(int last) -> when you need to iterate over range from 0 to last - 1, for example each index of string.size()

irange(int, int)- > for auto casting, for example size_t to int. Passing size_t as argument won't implicitly cast to Integer so it produces an error but it's safe.
