### PR TITLE
Allow iterator copy for lambda in transformed and filtered

### DIFF
--- a/include/boost/range/detail/default_constructible_unary_fn.hpp
+++ b/include/boost/range/detail/default_constructible_unary_fn.hpp
@@ -32,6 +32,23 @@ public:
         : m_impl(source)
     {
     }
+    default_constructible_unary_fn_wrapper(const default_constructible_unary_fn_wrapper& source)
+        : m_impl(source.m_impl)
+    {
+    }
+    default_constructible_unary_fn_wrapper& operator=(const default_constructible_unary_fn_wrapper& source)
+    {
+        if (source.m_impl)
+        {
+            // Lambda are not copy/move assignable.
+            m_impl.emplace(*source.m_impl);
+        }
+        else
+        {
+            m_impl.reset();
+        }
+        return *this;
+    }
     template<typename Arg>
     R operator()(const Arg& arg) const
     {

--- a/test/adaptor_test/transformed.cpp
+++ b/test/adaptor_test/transformed.cpp
@@ -38,6 +38,22 @@ namespace boost
             int operator()(int x) const { return x / 2; }
         };
 
+        struct lambda_init
+        {
+        };
+
+        struct lambda
+        {
+            lambda(const lambda_init& init) {}
+            lambda(const lambda& rhs) {}
+
+            int operator()(int x) const { return x + 1; }
+
+        private:
+            lambda() {}
+            lambda& operator=(const lambda& rhs) { return *this; }
+        };
+
         template< class Container, class TransformFn >
         void transformed_test_impl_core( Container& c, TransformFn fn )
         {
@@ -59,13 +75,29 @@ namespace boost
                                            test_result2.begin(), test_result2.end() );
         }
 
+        template< class Rng >
+        void check_copy_assign(Rng r)
+        {
+            Rng r2 = r;
+            r2 = r;
+        }
+
         template< class Container, class TransformFn >
+        void transformed_range_copy_assign(Container& c, TransformFn fn)
+        {
+            using namespace boost::adaptors;
+            check_copy_assign(c | transformed(fn));
+            check_copy_assign(adaptors::transform(c, fn));
+        }
+
+        template< class Container, class TransformFn, class TransformFnInit >
         void transformed_test_fn_impl()
         {
             using namespace boost::assign;
 
             Container c;
-            TransformFn fn;
+            TransformFnInit init;
+            TransformFn fn( init );
 
             // Test empty
             transformed_test_impl_core(c, fn);
@@ -77,13 +109,17 @@ namespace boost
             // Test many elements
             c += 1,1,1,2,2,2,2,2,3,4,5,6,7,8,9;
             transformed_test_impl_core(c, fn);
+
+            // test the range and iterator are copy assignable
+            transformed_range_copy_assign(c, fn);
         }
 
         template< class Container >
         void transformed_test_impl()
         {
-            transformed_test_fn_impl< Container, double_x >();
-            transformed_test_fn_impl< Container, halve_x >();
+            transformed_test_fn_impl< Container, double_x, double_x >();
+            transformed_test_fn_impl< Container, halve_x, halve_x >();
+            transformed_test_fn_impl< Container, lambda, lambda_init >();
         }
 
         void transformed_test()


### PR DESCRIPTION
Lambda has no default constructor nor a copy or move assignment.

range\test\adaptors.cpp is checking that produced ranges are copiable,
but it is not doing so the for lambda, or lambda like objects.

default_constructible_unary_fn uses an optional for default
construction.
I extended it to use its emplace facility to copy assign non copy
assignable types.
(see boost::optional 'Type Requierment':  'If T is not MoveAssignable,
it is still possible to reset the value of optional<T> using function
emplace():')

For info,
I got an implementation of the range-v3 calendar example working on boost::range.
In order to replace my function object structs with lambda, i needed the iterator to still be copy assignable, with non copy-assignable function objects (I might have been able to work around it, but it seemed fairly reasonable)

The current pull request allowed me to do it:
https://github.com/jeanphilippeD/SimpleExperiments/commit/4d81ff3133b0bfc2ef85fc7f34acf418dbbf34fb
