### PR TITLE
Don't assume that because type `T` is a range that `const T` is also a range.

### DIFF
--- a/include/boost/range/size_type.hpp
+++ b/include/boost/range/size_type.hpp
@@ -83,11 +83,6 @@ namespace boost
         detail::range_size<T>
     { };
 
-    template< class T >
-    struct range_size<const T > :
-        detail::range_size<T>
-    { };
-
 } // namespace boost
 
 


### PR DESCRIPTION
`size_type<const T>` erroneously dispatches to `detail::size_type_<T>`. That breaks for types that have non-const `begin`/`end` but that don't have const `begin`/`end`. The range-v3 library has such types.