### PR TITLE
Ticket 12754 - sfinea friendly boost::range_details::replace_holder overloads 

### DIFF
--- a/include/boost/range/adaptor/replaced.hpp
+++ b/include/boost/range/adaptor/replaced.hpp
@@ -101,12 +101,10 @@ namespace boost
             void operator=(const replace_holder&);
         };
 
-        template< class SinglePassRange >
+        template< class SinglePassRange, 
+                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
         inline replaced_range<SinglePassRange>
-        operator|(
-            SinglePassRange& r,
-            const replace_holder<
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>& f )
+        operator|(SinglePassRange& r, const replace_holder<RangeValueType>& f)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<SinglePassRange>));
@@ -114,12 +112,10 @@ namespace boost
             return replaced_range<SinglePassRange>(r, f.val1, f.val2);
         }
 
-        template< class SinglePassRange >
+        template< class SinglePassRange,
+                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
         inline replaced_range<const SinglePassRange>
-        operator|(
-            const SinglePassRange& r,
-            const replace_holder<
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>& f)
+        operator|(const SinglePassRange& r, const replace_holder<RangeValueType>& f)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<const SinglePassRange>));
@@ -139,11 +135,10 @@ namespace boost
                     range_detail::forwarder2<range_detail::replace_holder>();
         }
 
-        template<class SinglePassRange>
+        template< class SinglePassRange,
+                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
         inline replaced_range<SinglePassRange>
-        replace(SinglePassRange& rng,
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type from,
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type to)
+        replace(SinglePassRange& rng, RangeValueType from, RangeValueType to)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<SinglePassRange>));
@@ -151,11 +146,10 @@ namespace boost
             return replaced_range<SinglePassRange>(rng, from, to);
         }
 
-        template<class SinglePassRange>
+        template< class SinglePassRange,
+                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
         inline replaced_range<const SinglePassRange>
-        replace(const SinglePassRange& rng,
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type from,
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type to)
+        replace(const SinglePassRange& rng, RangeValueType from, RangeValueType to)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<const SinglePassRange>));


### PR DESCRIPTION
include\boost\range\adaptor\replaced.hpp

Make sure that the overload resolution doesn't choke on the value type factory when its considers the overload