### PR TITLE
Qualify boost::range_[const|mutable]_iterator

### DIFF
--- a/include/boost/range/has_range_iterator.hpp
+++ b/include/boost/range/has_range_iterator.hpp
@@ -37,9 +37,9 @@ namespace boost
             T,
             BOOST_DEDUCED_TYPENAME ::boost::enable_if<
                 BOOST_DEDUCED_TYPENAME mpl::eval_if<is_const<T>,
-                    has_type<range_const_iterator<
+                    has_type<boost::range_const_iterator<
                                 BOOST_DEDUCED_TYPENAME remove_const<T>::type> >,
-                    has_type<range_mutable_iterator<T> >
+                    has_type<boost::range_mutable_iterator<T> >
                 >::type
             >::type
         >
@@ -57,7 +57,7 @@ namespace boost
         struct has_range_const_iterator_impl<
             T,
             BOOST_DEDUCED_TYPENAME ::boost::enable_if<
-                has_type<range_const_iterator<T> >
+                has_type<boost::range_const_iterator<T> >
             >::type
         >
             : boost::mpl::true_


### PR DESCRIPTION
This commit from `develop` branch, we patch boost::range each release  due to lack of commit e7ebe14707130cda7b72e0ae5e93b17157fdb6a2
Relater to PR #40