### PR TITLE
Conditionally replace deprecated/removed C++98 function adapters and …

### DIFF
--- a/include/boost/range/algorithm/random_shuffle.hpp
+++ b/include/boost/range/algorithm/random_shuffle.hpp
@@ -14,11 +14,84 @@
 #include <boost/range/end.hpp>
 #include <boost/range/concepts.hpp>
 #include <algorithm>
+#ifdef BOOST_NO_CXX98_RANDOM_SHUFFLE
+#include <cstdlib>
+#endif
 
 namespace boost
 {
     namespace range
     {
+
+        namespace detail
+        {
+#ifdef BOOST_NO_CXX98_RANDOM_SHUFFLE
+
+// wrap std::rand as UniformRandomBitGenerator
+struct wrap_rand
+{
+    typedef unsigned int result_type;
+
+    static result_type (min)()
+    {
+        return 0;
+    }
+
+    static result_type (max)()
+    {
+        return RAND_MAX;
+    }
+
+    result_type operator()()
+    {
+        return std::rand();
+    }
+};
+
+template< class RandomIt >
+inline void random_shuffle(RandomIt first, RandomIt last)
+{
+    std::shuffle(first, last, wrap_rand());
+}
+
+// wrap Generator as UniformRandomBitGenerator
+template< class Generator >
+struct wrap_generator
+{
+    typedef unsigned int result_type;
+    static const int max_arg = ((0u - 1u) >> 2) + 1;
+    Generator& g;
+
+    wrap_generator(Generator& gen) : g(gen) {}
+
+    static result_type (min)()
+    {
+        return 0;
+    }
+
+    static result_type (max)()
+    {
+        return max_arg - 1;
+    }
+
+    result_type operator()()
+    {
+        return static_cast<result_type>(g(max_arg));
+    }
+};
+
+template< class RandomIt, class Generator >
+inline void random_shuffle(RandomIt first, RandomIt last, Generator& gen)
+{
+    std::shuffle(first, last, wrap_generator< Generator >(gen));
+}
+
+#else
+    
+using std::random_shuffle;
+
+#endif  
+        } // namespace detail
 
 /// \brief template function random_shuffle
 ///
@@ -30,7 +103,7 @@ template<class RandomAccessRange>
 inline RandomAccessRange& random_shuffle(RandomAccessRange& rng)
 {
     BOOST_RANGE_CONCEPT_ASSERT(( RandomAccessRangeConcept<RandomAccessRange> ));
-    std::random_shuffle(boost::begin(rng), boost::end(rng));
+    detail::random_shuffle(boost::begin(rng), boost::end(rng));
     return rng;
 }
 
@@ -39,7 +112,7 @@ template<class RandomAccessRange>
 inline const RandomAccessRange& random_shuffle(const RandomAccessRange& rng)
 {
     BOOST_RANGE_CONCEPT_ASSERT(( RandomAccessRangeConcept<const RandomAccessRange> ));
-    std::random_shuffle(boost::begin(rng), boost::end(rng));
+    detail::random_shuffle(boost::begin(rng), boost::end(rng));
     return rng;
 }
 
@@ -48,7 +121,7 @@ template<class RandomAccessRange, class Generator>
 inline RandomAccessRange& random_shuffle(RandomAccessRange& rng, Generator& gen)
 {
     BOOST_RANGE_CONCEPT_ASSERT(( RandomAccessRangeConcept<RandomAccessRange> ));
-    std::random_shuffle(boost::begin(rng), boost::end(rng), gen);
+    detail::random_shuffle(boost::begin(rng), boost::end(rng), gen);
     return rng;
 }
 
@@ -57,7 +130,7 @@ template<class RandomAccessRange, class Generator>
 inline const RandomAccessRange& random_shuffle(const RandomAccessRange& rng, Generator& gen)
 {
     BOOST_RANGE_CONCEPT_ASSERT(( RandomAccessRangeConcept<const RandomAccessRange> ));
-    std::random_shuffle(boost::begin(rng), boost::end(rng), gen);
+    detail::random_shuffle(boost::begin(rng), boost::end(rng), gen);
     return rng;
 }
 

--- a/test/ticket_5486.cpp
+++ b/test/ticket_5486.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <functional>
 #include <vector>
 
 namespace boost
@@ -22,9 +21,12 @@ namespace boost
     namespace
     {
         class TestTicket5486Pred
-            : public std::binary_function<int,int,bool>
         {
         public:
+            typedef int first_argument_type;
+            typedef int second_argument_type;
+            typedef bool result_type;
+
             explicit TestTicket5486Pred(int x) {}
             bool operator()(int,int) const { return true; }
         private:


### PR DESCRIPTION
…std::random_shuffle by equivalents.

Signed-off-by: Daniela Engert <dani@ngrt.de>