### PR TITLE
Fix breakage in replaced adaptor for C++03

### DIFF
--- a/include/boost/range/adaptor/replaced.hpp
+++ b/include/boost/range/adaptor/replaced.hpp
@@ -101,10 +101,9 @@ namespace boost
             void operator=(const replace_holder&);
         };
 
-        template< class SinglePassRange, 
-                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
+        template< class SinglePassRange, class Value >
         inline replaced_range<SinglePassRange>
-        operator|(SinglePassRange& r, const replace_holder<RangeValueType>& f)
+        operator|(SinglePassRange& r, const replace_holder<Value>& f)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<SinglePassRange>));
@@ -112,10 +111,9 @@ namespace boost
             return replaced_range<SinglePassRange>(r, f.val1, f.val2);
         }
 
-        template< class SinglePassRange,
-                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
+        template< class SinglePassRange, class Value >
         inline replaced_range<const SinglePassRange>
-        operator|(const SinglePassRange& r, const replace_holder<RangeValueType>& f)
+        operator|(const SinglePassRange& r, const replace_holder<Value>& f)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<const SinglePassRange>));
@@ -135,10 +133,9 @@ namespace boost
                     range_detail::forwarder2<range_detail::replace_holder>();
         }
 
-        template< class SinglePassRange,
-                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
+        template< class SinglePassRange, class Value >
         inline replaced_range<SinglePassRange>
-        replace(SinglePassRange& rng, RangeValueType from, RangeValueType to)
+        replace(SinglePassRange& rng, Value from, Value to)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<SinglePassRange>));
@@ -146,10 +143,9 @@ namespace boost
             return replaced_range<SinglePassRange>(rng, from, to);
         }
 
-        template< class SinglePassRange,
-                  class RangeValueType = BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>
+        template< class SinglePassRange, class Value >
         inline replaced_range<const SinglePassRange>
-        replace(const SinglePassRange& rng, RangeValueType from, RangeValueType to)
+        replace(const SinglePassRange& rng, Value from, Value to)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<const SinglePassRange>));

--- a/include/boost/range/adaptor/replaced_if.hpp
+++ b/include/boost/range/adaptor/replaced_if.hpp
@@ -103,13 +103,9 @@ namespace boost
             T m_to;
         };
 
-        template< class Pred, class SinglePassRange >
+        template< class Pred, class SinglePassRange, class Value >
         inline replaced_if_range<Pred, SinglePassRange>
-        operator|(
-            SinglePassRange& r,
-            const replace_if_holder<
-                Pred,
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>& f)
+        operator|(SinglePassRange& r, const replace_if_holder<Pred, Value>& f)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<SinglePassRange>));
@@ -118,13 +114,9 @@ namespace boost
                 r, f.pred(), f.to());
         }
 
-        template< class Pred, class SinglePassRange >
+        template< class Pred, class SinglePassRange, class Value >
         inline replaced_if_range<Pred, const SinglePassRange>
-        operator|(
-            const SinglePassRange& r,
-            const replace_if_holder<
-                Pred,
-                BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type>& f)
+        operator|(const SinglePassRange& r, const replace_if_holder<Pred, Value>& f)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<const SinglePassRange>));
@@ -145,10 +137,9 @@ namespace boost
                     range_detail::forwarder2TU<range_detail::replace_if_holder>();
         }
 
-        template<class Pred, class SinglePassRange>
+        template< class Pred, class SinglePassRange, class Value >
         inline replaced_if_range<Pred, SinglePassRange>
-        replace_if(SinglePassRange& rng, Pred pred,
-                   BOOST_DEDUCED_TYPENAME range_value<SinglePassRange>::type to)
+        replace_if(SinglePassRange& rng, Pred pred, Value to)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<SinglePassRange>));
@@ -157,12 +148,9 @@ namespace boost
                 rng, pred, to);
         }
 
-        template<class Pred, class SinglePassRange>
+        template< class Pred, class SinglePassRange, class Value >
         inline replaced_if_range<Pred, const SinglePassRange>
-        replace_if(
-            const SinglePassRange& rng,
-            Pred pred,
-            BOOST_DEDUCED_TYPENAME range_value<const SinglePassRange>::type to)
+        replace_if(const SinglePassRange& rng, Pred pred, Value to)
         {
             BOOST_RANGE_CONCEPT_ASSERT((
                 SinglePassRangeConcept<const SinglePassRange>));


### PR DESCRIPTION
This fixes a C++03 breakage introduced in #48.

Additionally, this PR adds `Value` template parameter to `operator|(rng, replaced_if)` to make it consistent with `operator|(rng, replaced)`.