### PR TITLE
Fix transformed test compile error on GCC 5.4

### DIFF
--- a/test/adaptor_test/transformed.cpp
+++ b/test/adaptor_test/transformed.cpp
@@ -44,6 +44,8 @@ namespace boost
 
         struct lambda
         {
+            typedef int result_type;
+
             lambda(const lambda_init& init) {}
             lambda(const lambda& rhs) {}
 


### PR DESCRIPTION
The function object 'lambda' did not provide result_type like the other
function objects did.

The test now compile and pass using'b2'