### PR TITLE
Include boost/next_prior.hpp where needed

### DIFF
--- a/include/boost/range/adaptor/sliced.hpp
+++ b/include/boost/range/adaptor/sliced.hpp
@@ -15,6 +15,7 @@
 #include <boost/range/size_type.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/concepts.hpp>
+#include <boost/next_prior.hpp>
 
 namespace boost
 {

--- a/include/boost/range/detail/microsoft.hpp
+++ b/include/boost/range/detail/microsoft.hpp
@@ -58,6 +58,7 @@
 #include <boost/type_traits/remove_cv.hpp>
 #include <boost/utility/addressof.hpp>
 #include <boost/utility/enable_if.hpp> // disable_if
+#include <boost/next_prior.hpp>
 
 #if !defined(BOOST_RANGE_DETAIL_MICROSOFT_RANGE_VERSION_1)
     #include <boost/range/mutable_iterator.hpp>

--- a/include/boost/range/detail/range_return.hpp
+++ b/include/boost/range/detail/range_return.hpp
@@ -12,6 +12,7 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/iterator_range.hpp>
+#include <boost/next_prior.hpp>
 
 namespace boost
 {

--- a/include/boost/range/iterator_range_core.hpp
+++ b/include/boost/range/iterator_range_core.hpp
@@ -42,6 +42,7 @@
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/range/detail/safe_bool.hpp>
 #include <boost/utility/enable_if.hpp>
+#include <boost/next_prior.hpp>
 #include <iterator>
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
A recent change to boost/utility.hpp removed the include of this header,
so now it's needed for boost::prior and boost::next.

https://github.com/boostorg/utility/commit/b74f49f1e56e0be7eda4085de9aa0107526b423e