### PR TITLE
Fix Error C4596: 'difference_type': illegal qualified name in member declaration

### DIFF
--- a/include/boost/range/concepts.hpp
+++ b/include/boost/range/concepts.hpp
@@ -252,7 +252,7 @@ namespace boost {
                  n = i - j;
              }
          private:
-             BOOST_DEDUCED_TYPENAME RandomAccessIteratorConcept::difference_type n;
+             BOOST_DEDUCED_TYPENAME difference_type n;
              Iterator i;
              Iterator j;
  #endif

--- a/include/boost/range/concepts.hpp
+++ b/include/boost/range/concepts.hpp
@@ -252,7 +252,12 @@ namespace boost {
                  n = i - j;
              }
          private:
+ // MSVC 14.1 - avoid C4596: 'difference_type': illegal qualified name in member declaration
+ #if defined(_MSC_VER) && _MSC_VER >= 1912 
              BOOST_DEDUCED_TYPENAME difference_type n;
+ #else
+             BOOST_DEDUCED_TYPENAME RandomAccessIteratorConcept::difference_type n;
+ #endif
              Iterator i;
              Iterator j;
  #endif


### PR DESCRIPTION
Hi there, 

When compiling against boost 1.66.0 with VS 2017 Professional 15.5.6 and MSVC 14.1, a wild C4596 Illegal Qualified Name' appeared.

The fix was a simple one, I hope I used the right branch - this is my first ever PR. We compile with /Wall and treat warning as errors..

I hope this is useful.

