### PR TITLE
Add ADL guard namespace for boost::distance(rng)

### DIFF
--- a/include/boost/range/distance.hpp
+++ b/include/boost/range/distance.hpp
@@ -23,12 +23,17 @@
 namespace boost
 {
 
-    template< class T >
-    inline BOOST_CXX14_CONSTEXPR BOOST_DEDUCED_TYPENAME range_difference<T>::type
-    distance( const T& r )
+    namespace range_distance_adl_barrier
     {
-        return boost::distance( boost::begin( r ), boost::end( r ) );
+        template< class T >
+        inline BOOST_CXX14_CONSTEXPR BOOST_DEDUCED_TYPENAME range_difference<T>::type
+        distance( const T& r )
+        {
+            return boost::iterators::distance( boost::begin( r ), boost::end( r ) );
+        }
     }
+
+    using namespace range_distance_adl_barrier;
 
 } // namespace 'boost'
 


### PR DESCRIPTION
Move `distance` function template into the ADL barrier namespace and pull the name by a using-directive. This fix should be OK, since [Boost.Range documentation](https://www.boost.org/doc/libs/develop/libs/range/doc/html/range/reference/concept_implementation/semantics/functions.html) explicitly forbids unqualified call to `distance`.
- C++20 will have `std::distance(rng)` function template. This fix prevents ambiguity errors between `boost::distance(rng)` and `std::distance(rng)` caused by accidental ADL.
- This fix may be necessary to fix boostorg/iterator#43.
- Drive-by fix: it's OK to use `boost::distance(it1, it2)`, but [Boost.Iterator documentation](https://github.com/boostorg/iterator/blob/develop/doc/advance.rst) advertises only `boost::iterators::distance(it1, it2)`. So let's use it.