### PR TITLE
Add basic CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright 2019 Sam Day
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.range is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostRange LANGUAGES CXX)
+
+add_library(boost_range INTERFACE)
+add_library(Boost::range ALIAS boost_range)
+
+target_include_directories(boost_range INTERFACE include)
+
+target_link_libraries(boost_range
+        INTERFACE
+        Boost::array
+        Boost::assert
+        Boost::concept_check
+        Boost::config
+        Boost::core
+        Boost::detail
+        Boost::functional
+        Boost::iterator
+        Boost::mpl
+        Boost::numeric_conversion
+        Boost::optional
+        Boost::preprocessor
+        Boost::regex
+        Boost::static_assert
+        Boost::tuple
+        Boost::type_traits
+        Boost::utility
+        )


### PR DESCRIPTION
Just directly ripping off the work I've noticed @Mike-Devel doing across a bunch of Boost modules.

I determined the list of dependencies by grepping for `#include` directives. I don't know this library very well, so let me know if any of the dependencies don't make sense.

This PR depends on:

 * [algorithm](https://github.com/boostorg/algorithm/pull/60) (cyclic!)
 * [numeric_conversion](https://github.com/boostorg/numeric_conversion/pull/17)
 * [regex](https://github.com/boostorg/regex/pull/83)
 * [unordered](https://github.com/boostorg/unordered/pull/13)
