### PR TITLE
Fix any_range with non-reference references can cause UB

### DIFF
--- a/include/boost/range/detail/any_iterator_interface.hpp
+++ b/include/boost/range/detail/any_iterator_interface.hpp
@@ -13,12 +13,9 @@
 #include <boost/range/detail/any_iterator_buffer.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/mpl/not.hpp>
-#include <boost/type_traits/add_const.hpp>
-#include <boost/type_traits/add_reference.hpp>
-#include <boost/type_traits/is_abstract.hpp>
-#include <boost/type_traits/is_copy_constructible.hpp>
+#include <boost/type_traits/decay.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_reference.hpp>
-#include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
 namespace boost
@@ -40,16 +37,11 @@ namespace boost
         template<class T>
         struct reference_as_value_type_generator
         {
-            typedef typename remove_const<
-                typename remove_reference<T>::type
-            >::type const_reference_stripped_type;
+            typedef typename decay<T>::type decayed_type;
 
             typedef typename mpl::if_<
-                typename mpl::or_<
-                    mpl::not_<typename is_abstract<const_reference_stripped_type>::type>,
-                    typename is_copy_constructible<const_reference_stripped_type>::type
-                >::type,
-                const_reference_stripped_type,
+                typename is_convertible<const decayed_type&, decayed_type>::type,
+                decayed_type,
                 T
             >::type type;
         };

--- a/include/boost/range/detail/any_iterator_interface.hpp
+++ b/include/boost/range/detail/any_iterator_interface.hpp
@@ -14,7 +14,7 @@
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/add_reference.hpp>
-#include <boost/type_traits/is_copy_constructible.hpp>
+#include <boost/type_traits/is_abstract.hpp>
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
@@ -39,15 +39,15 @@ namespace boost
         struct reference_as_value_type_generator
         {
             typedef typename mpl::if_<
-                typename is_copy_constructible<
+                typename is_abstract<
                     typename remove_const<
                         typename remove_reference<T>::type
                     >::type
                 >::type,
+                T,
                 typename remove_const<
                     typename remove_reference<T>::type
-                >::type,
-                T
+                >::type
             >::type type;
         };
 

--- a/include/boost/range/detail/any_iterator_interface.hpp
+++ b/include/boost/range/detail/any_iterator_interface.hpp
@@ -13,9 +13,9 @@
 #include <boost/range/detail/any_iterator_buffer.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/mpl/not.hpp>
-#include <boost/type_traits/decay.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_reference.hpp>
+#include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
 namespace boost
@@ -37,11 +37,13 @@ namespace boost
         template<class T>
         struct reference_as_value_type_generator
         {
-            typedef typename decay<T>::type decayed_type;
+            typedef typename remove_reference<
+                typename remove_const<T>::type
+            >::type value_type;
 
             typedef typename mpl::if_<
-                typename is_convertible<const decayed_type&, decayed_type>::type,
-                decayed_type,
+                typename is_convertible<const value_type&, value_type>::type,
+                value_type,
                 T
             >::type type;
         };

--- a/include/boost/range/detail/any_iterator_interface.hpp
+++ b/include/boost/range/detail/any_iterator_interface.hpp
@@ -12,9 +12,11 @@
 
 #include <boost/range/detail/any_iterator_buffer.hpp>
 #include <boost/iterator/iterator_categories.hpp>
+#include <boost/mpl/not.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/is_abstract.hpp>
+#include <boost/type_traits/is_copy_constructible.hpp>
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
@@ -38,16 +40,17 @@ namespace boost
         template<class T>
         struct reference_as_value_type_generator
         {
+            typedef typename remove_const<
+                typename remove_reference<T>::type
+            >::type const_reference_stripped_type;
+
             typedef typename mpl::if_<
-                typename is_abstract<
-                    typename remove_const<
-                        typename remove_reference<T>::type
-                    >::type
+                typename mpl::or_<
+                    mpl::not_<typename is_abstract<const_reference_stripped_type>::type>,
+                    typename is_copy_constructible<const_reference_stripped_type>::type
                 >::type,
-                T,
-                typename remove_const<
-                    typename remove_reference<T>::type
-                >::type
+                const_reference_stripped_type,
+                T
             >::type type;
         };
 

--- a/include/boost/range/detail/any_iterator_interface.hpp
+++ b/include/boost/range/detail/any_iterator_interface.hpp
@@ -14,6 +14,7 @@
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/add_reference.hpp>
+#include <boost/type_traits/is_copy_constructible.hpp>
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
@@ -35,15 +36,18 @@ namespace boost
         };
 
         template<class T>
-        struct mutable_reference_type_generator
+        struct reference_as_value_type_generator
         {
             typedef typename mpl::if_<
-                typename mpl::and_<
-                    typename is_const<T>::type,
-                    typename mpl::not_<typename is_reference<T>::type>::type
+                typename is_copy_constructible<
+                    typename remove_const<
+                        typename remove_reference<T>::type
+                    >::type
                 >::type,
-                T,
-                typename add_reference<T>::type
+                typename remove_const<
+                    typename remove_reference<T>::type
+                >::type,
+                T
             >::type type;
         };
 
@@ -53,16 +57,12 @@ namespace boost
         >
         struct any_incrementable_iterator_interface
         {
-            typedef typename mutable_reference_type_generator<
-                Reference
-            >::type reference;
-
+            typedef Reference reference;
             typedef typename const_reference_type_generator<
                 Reference
             >::type const_reference;
-
-            typedef typename remove_const<
-                typename remove_reference<Reference>::type
+            typedef typename reference_as_value_type_generator<
+                Reference
             >::type reference_as_value_type;
 
             typedef Buffer buffer_type;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -81,6 +81,7 @@ test-suite range :
     [ range-test adaptor_test/type_erased_forward ]
     [ range-test adaptor_test/type_erased_bidirectional ]
     [ range-test adaptor_test/type_erased_random_access ]
+    [ range-test adaptor_test/type_erased_transformed ]
     [ range-test adaptor_test/uniqued ]
     [ range-test adaptor_test/adjacent_filtered_example ]
     [ range-test adaptor_test/copied_example ]

--- a/test/adaptor_test/type_erased_transformed.cpp
+++ b/test/adaptor_test/type_erased_transformed.cpp
@@ -1,0 +1,66 @@
+// Boost.Range library
+//
+//  Copyright Neil Groves 2014. Use, modification and
+//  distribution is subject to the Boost Software License, Version
+//  1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/range/adaptor/type_erased.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/numeric.hpp>
+#include "type_erased_test.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+namespace boost_range_adaptor_type_erased_test
+{
+    namespace
+    {
+
+typedef boost::any_range<
+    int,
+    boost::random_access_traversal_tag,
+    int,
+    std::ptrdiff_t
+> any_integer_value_range;
+
+struct get_fn
+{
+    boost::int32_t operator()(const MockType& val) const
+    {
+        return val.get();
+    }
+};
+
+int accumulate_any_integer_value_range(any_integer_value_range rng)
+{
+    return boost::accumulate(rng, 0);
+}
+
+void test_type_erased_transformed()
+{
+    std::vector<MockType> v{1,2,3,4,5};
+
+    const int sum = accumulate_any_integer_value_range(
+        v | boost::adaptors::transformed(get_fn()));
+
+    BOOST_CHECK_EQUAL(15, sum);
+}
+
+    } // anonymous namespace
+} // namespace boost_range_adaptor_type_erased_test
+
+boost::unit_test::test_suite*
+init_unit_test_suite(int, char*[])
+{
+    boost::unit_test::test_suite* test
+        = BOOST_TEST_SUITE("RangeTestSuite.adaptor.type_erased_transformed");
+
+    test->add(
+        BOOST_TEST_CASE(
+            &boost_range_adaptor_type_erased_test::test_type_erased_transformed));
+
+    return test;
+}

--- a/test/adaptor_test/type_erased_transformed.cpp
+++ b/test/adaptor_test/type_erased_transformed.cpp
@@ -28,6 +28,7 @@ typedef boost::any_range<
 
 struct get_fn
 {
+    typedef boost::int32_t result_type;
     boost::int32_t operator()(const MockType& val) const
     {
         return val.get();

--- a/test/adaptor_test/type_erased_transformed.cpp
+++ b/test/adaptor_test/type_erased_transformed.cpp
@@ -41,7 +41,7 @@ int accumulate_any_integer_value_range(any_integer_value_range rng)
 
 void test_type_erased_transformed()
 {
-    std::vector<MockType> v{1,2,3,4,5};
+    std::vector<MockType> v(5, MockType(3));
 
     const int sum = accumulate_any_integer_value_range(
         v | boost::adaptors::transformed(get_fn()));


### PR DESCRIPTION
This pull request fixes an issue with non-reference references.

The issue was introduced in 79d2a66831af16f29befaa4d32461928b9431a15. In order to make `any_range` compatible with non-copyable types, a check was introduced adding a reference to the `Reference` template parameter unless it was a non-reference const type. This fixed the problem of non-copyable types but made it impossible to return value types from an `any_range` such as when using `adaptors::transformed`. 

The real issue however was the method `clone_reference_as_value` in `any_incrementable_iterator_interface`:

```c++
typedef typename remove_const<
    typename remove_reference<Reference>::type
>::type reference_as_value_type;

virtual any_incrementable_iterator_interface<reference_as_value_type, Buffer>*
    clone_reference_as_value(buffer_type& buffer) const = 0;
```

It clones the iterator and replaces its `Reference` parameter with a non-const non-reference version. This is why even though `any_range` was instantiated with a reference `Reference` parameter, the non-reference version was compiled anyway. 

In order to fix this, I added a check here stripping `Reference` off its referenceness unless `Reference` is non-copyable.

Fixes #73 / https://svn.boost.org/trac10/ticket/10493