### PR TITLE
Fix usage of deprecated headers

### DIFF
--- a/include/boost/range/detail/collection_traits_detail.hpp
+++ b/include/boost/range/detail/collection_traits_detail.hpp
@@ -12,6 +12,8 @@
 
 #include <cstddef>
 #include <string>
+#include <utility>
+#include <iterator>
 #include <boost/type_traits/is_array.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/type_traits/is_const.hpp>
@@ -22,7 +24,6 @@
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/fold.hpp>
-#include <boost/detail/iterator.hpp>
 
 // Container traits implementation ---------------------------------------------------------
 
@@ -36,7 +37,7 @@ namespace boost {
             /*
                 Wraps std::container compliant containers
             */
-            template< typename ContainerT >     
+            template< typename ContainerT >
             struct default_container_traits
             {
                 typedef typename ContainerT::value_type value_type;
@@ -49,7 +50,7 @@ namespace boost {
                     >::type result_iterator;
                 typedef typename ContainerT::difference_type difference_type;
                 typedef typename ContainerT::size_type size_type;
-                
+
                 // static operations
                 template< typename C >
                 static size_type size( const C& c )
@@ -120,11 +121,11 @@ namespace boost {
             {
                 typedef typename PairT::first_type element_type;
 
-                typedef typename ::boost::detail::
-                    iterator_traits<element_type>::value_type value_type;
+                typedef typename
+                    std::iterator_traits<element_type>::value_type value_type;
                 typedef std::size_t size_type;
-                typedef typename ::boost::detail::
-                    iterator_traits<element_type>::difference_type difference_type;
+                typedef typename
+                    std::iterator_traits<element_type>::difference_type difference_type;
 
                 typedef element_type iterator;
                 typedef element_type const_iterator;
@@ -186,7 +187,7 @@ namespace boost {
                 BOOST_STATIC_CONSTANT( size_type, array_size = sz );
             };
 
-            
+
             // array length resolving
             /*
                 Lenght of string contained in a static array could
@@ -243,7 +244,7 @@ namespace boost {
                         else
                             return std::char_traits<char>::length(a);
                     }
-                    
+
                     template< typename A >
                     static bool empty( const A& a )
                     {
@@ -303,7 +304,7 @@ namespace boost {
                         const_iterator,
                         iterator 
                     >::type result_iterator;
-                
+
             private:
                 // resolve array size
                 typedef typename
@@ -327,7 +328,7 @@ namespace boost {
                 {
                     return array_length_type::empty(a);
                 }
-                
+
 
                 template< typename A >
                 static iterator begin( A& a )

--- a/test/adaptor_test/chained.cpp
+++ b/test/adaptor_test/chained.cpp
@@ -19,7 +19,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/algorithm/copy.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
@@ -87,6 +87,8 @@ void chained_adaptors_test()
     sep.push_back("aghj");
 
     std::set<foo> foos;
+
+    using namespace boost::placeholders;
 
     boost::copy(sep
         | boost::adaptors::transformed(boost::bind(&foo::from_string, _1))

--- a/test/adaptor_test/transformed.cpp
+++ b/test/adaptor_test/transformed.cpp
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/range/algorithm_ext.hpp>
 
 #include <algorithm>
@@ -140,6 +140,7 @@ namespace boost
         void transformed_bind()
         {
             using namespace boost::adaptors;
+            using namespace boost::placeholders;
 
             std::vector<foo_bind> input(5);
             std::vector<int> output;

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -35,9 +35,8 @@
 #endif
 
 #include <boost/assign.hpp>
-#include <boost/config.hpp>    
+#include <boost/config.hpp>
 #include <boost/array.hpp>
-#include <boost/bind.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/value_type.hpp>

--- a/test/algorithm_test/binary_search.cpp
+++ b/test/algorithm_test/binary_search.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/equal_range.cpp
+++ b/test/algorithm_test/equal_range.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/generate.cpp
+++ b/test/algorithm_test/generate.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/heap.cpp
+++ b/test/algorithm_test/heap.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/includes.cpp
+++ b/test/algorithm_test/includes.cpp
@@ -11,7 +11,6 @@
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/inplace_merge.cpp
+++ b/test/algorithm_test/inplace_merge.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/lower_bound.cpp
+++ b/test/algorithm_test/lower_bound.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <boost/range/algorithm/lower_bound.hpp>
 #include "../test_driver/range_return_test_driver.hpp"
 #include <algorithm>

--- a/test/algorithm_test/max_element.cpp
+++ b/test/algorithm_test/max_element.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <boost/range/iterator.hpp>
 #include "../test_driver/range_return_test_driver.hpp"
 #include <algorithm>

--- a/test/algorithm_test/merge.cpp
+++ b/test/algorithm_test/merge.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/min_element.cpp
+++ b/test/algorithm_test/min_element.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <boost/range/iterator.hpp>
 #include "../test_driver/range_return_test_driver.hpp"
 #include <algorithm>

--- a/test/algorithm_test/nth_element.cpp
+++ b/test/algorithm_test/nth_element.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/partial_sort.cpp
+++ b/test/algorithm_test/partial_sort.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/partition.cpp
+++ b/test/algorithm_test/partition.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include "../test_driver/range_return_test_driver.hpp"
 #include <algorithm>
 #include <functional>

--- a/test/algorithm_test/random_shuffle.cpp
+++ b/test/algorithm_test/random_shuffle.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include "../test_function/counted_function.hpp"
 #include <algorithm>
 #include <functional>

--- a/test/algorithm_test/remove.cpp
+++ b/test/algorithm_test/remove.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/remove_copy.cpp
+++ b/test/algorithm_test/remove_copy.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/remove_copy_if.cpp
+++ b/test/algorithm_test/remove_copy_if.cpp
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>
@@ -64,6 +64,8 @@ namespace
     template< class Container >
     void test_remove_copy_if_( const Container& c, int to_remove )
     {
+        using namespace boost::placeholders;
+
         test_remove_copy_if_impl(c, boost::bind(std::equal_to<int>(), _1, to_remove));
         test_remove_copy_if_impl(c, boost::bind(std::not_equal_to<int>(), _1, to_remove));
     }

--- a/test/algorithm_test/remove_if.cpp
+++ b/test/algorithm_test/remove_if.cpp
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>
@@ -59,6 +59,8 @@ namespace boost
         template< class Container >
         void test_remove_if_( const Container& c, int to_remove )
         {
+            using namespace boost::placeholders;
+
             test_remove_if_impl(c, boost::bind(std::equal_to<int>(), _1, to_remove));
             test_remove_if_impl(c, boost::bind(std::not_equal_to<int>(), _1, to_remove));
         }

--- a/test/algorithm_test/replace_copy.cpp
+++ b/test/algorithm_test/replace_copy.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/replace_copy_if.cpp
+++ b/test/algorithm_test/replace_copy_if.cpp
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>
@@ -66,6 +66,8 @@ namespace
     template< class Container >
     void test_replace_copy_if_( const Container& c, int to_replace )
     {
+        using namespace boost::placeholders;
+
         test_replace_copy_if_impl(c, boost::bind(std::equal_to<int>(), _1, to_replace));
         test_replace_copy_if_impl(c, boost::bind(std::not_equal_to<int>(), _1, to_replace));
     }

--- a/test/algorithm_test/replace_if.cpp
+++ b/test/algorithm_test/replace_if.cpp
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>
@@ -29,6 +29,8 @@ namespace boost
         template< class Container, class UnaryPredicate >
         void test_replace_if_impl(Container& cont, UnaryPredicate pred)
         {
+            using namespace boost::placeholders;
+
             const int what = 2;
             const int with_what = 5;
 

--- a/test/algorithm_test/reverse.cpp
+++ b/test/algorithm_test/reverse.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/reverse_copy.cpp
+++ b/test/algorithm_test/reverse_copy.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/rotate.cpp
+++ b/test/algorithm_test/rotate.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/rotate_copy.cpp
+++ b/test/algorithm_test/rotate_copy.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/set_difference.cpp
+++ b/test/algorithm_test/set_difference.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/set_intersection.cpp
+++ b/test/algorithm_test/set_intersection.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/set_symmetric_difference.cpp
+++ b/test/algorithm_test/set_symmetric_difference.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/set_union.cpp
+++ b/test/algorithm_test/set_union.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/sort.cpp
+++ b/test/algorithm_test/sort.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/stable_partition.cpp
+++ b/test/algorithm_test/stable_partition.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include "../test_driver/range_return_test_driver.hpp"
 #include <algorithm>
 #include <functional>

--- a/test/algorithm_test/stable_sort.cpp
+++ b/test/algorithm_test/stable_sort.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/swap_ranges.cpp
+++ b/test/algorithm_test/swap_ranges.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/unique.cpp
+++ b/test/algorithm_test/unique.cpp
@@ -15,7 +15,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <boost/config.hpp>
 #include "../test_driver/range_overload_test_driver.hpp"
 #include <algorithm>

--- a/test/algorithm_test/unique_copy.cpp
+++ b/test/algorithm_test/unique_copy.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/test/algorithm_test/upper_bound.cpp
+++ b/test/algorithm_test/upper_bound.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/assign.hpp>
-#include <boost/bind.hpp>
 #include "../test_driver/range_return_test_driver.hpp"
 #include <algorithm>
 #include <functional>

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -28,6 +28,7 @@
 #include <boost/config.hpp>
 #include <vector>
 #include <fstream>
+#include <iterator>
 #include <algorithm>
 
 namespace
@@ -146,7 +147,7 @@ void check_char()
     char*            char_s2 = a_string.mutable_sz();
 
     BOOST_STATIC_ASSERT(( is_same<  range_value<char_iterator_t>::type,
-                                    detail::iterator_traits<char_iterator_t>::value_type>::value ));
+                                    std::iterator_traits<char_iterator_t>::value_type>::value ));
     BOOST_STATIC_ASSERT(( is_same<  range_iterator<char_iterator_t>::type, char_iterator_t >::value ));
 
     BOOST_STATIC_ASSERT(( is_same<  range_difference<char_iterator_t>::type,
@@ -225,11 +226,11 @@ void check_string()
     wchar_t*        char_ws2     = a_wide_string.mutable_sz();
 
     BOOST_STATIC_ASSERT(( is_same< range_value<wchar_iterator_t>::type,
-                                   detail::iterator_traits<wchar_iterator_t>::value_type>::value ));
+                                   std::iterator_traits<wchar_iterator_t>::value_type>::value ));
     BOOST_STATIC_ASSERT(( is_same< range_iterator<wchar_iterator_t>::type, wchar_iterator_t >::value ));
     BOOST_STATIC_ASSERT(( is_same< range_iterator<const wchar_t*>::type, const wchar_t* >::value ));
     BOOST_STATIC_ASSERT(( is_same< range_difference<wchar_iterator_t>::type,
-                                   detail::iterator_traits<wchar_iterator_t>::difference_type >::value ));
+                                   std::iterator_traits<wchar_iterator_t>::difference_type >::value ));
     BOOST_STATIC_ASSERT(( is_same< range_size<wchar_iterator_t>::type, std::size_t >::value ));
     BOOST_STATIC_ASSERT(( is_same< range_iterator<wchar_iterator_t>::type, wchar_iterator_t >::value ));
     BOOST_STATIC_ASSERT(( is_same< range_iterator<const wchar_t*>::type, const wchar_t* >::value ));


### PR DESCRIPTION
This silences warnings about including deprecated headers `boost/detail/iterator.hpp` and `boost/bind.hpp`.