### PR TITLE
Remove deprecated headers in metafunctions.hpp (Issue #106)

### DIFF
--- a/include/boost/range/metafunctions.hpp
+++ b/include/boost/range/metafunctions.hpp
@@ -17,10 +17,7 @@
 
 #include <boost/range/iterator.hpp>
 #include <boost/range/has_range_iterator.hpp>
-#include <boost/range/result_iterator.hpp>
 #include <boost/range/reverse_iterator.hpp>
-#include <boost/range/const_reverse_iterator.hpp>
-#include <boost/range/reverse_result_iterator.hpp>
 #include <boost/range/value_type.hpp>
 #include <boost/range/size_type.hpp>
 #include <boost/range/difference_type.hpp>


### PR DESCRIPTION
There are three headers included in this file which are deprecated.
- They each pull in a header that is already included.
- They each define a deprecated struct (`range_result_iterator`, `range_const_reverse_iterator`, and `range_reverse_result_iterator`, respectively.
However:
- boost itself does not rely on these structs being defined via inclusion of this header
- users of boost can simply add a #include of the required file, or (better) change their usage to avoid the deprecated `struct`s.