### PR TITLE
Add missing include

### DIFF
--- a/include/boost/range/detail/has_member_size.hpp
+++ b/include/boost/range/detail/has_member_size.hpp
@@ -15,6 +15,7 @@
 #include <boost/type_traits/is_member_function_pointer.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/cstdint.hpp>
 
 namespace boost


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds. @vgvassilev