### PR TITLE
Replace include of outdated boost/cast.hpp header

### DIFF
--- a/include/boost/range/detail/any_iterator_wrapper.hpp
+++ b/include/boost/range/detail/any_iterator_wrapper.hpp
@@ -10,7 +10,7 @@
 #ifndef BOOST_RANGE_DETAIL_ANY_ITERATOR_WRAPPER_HPP_INCLUDED
 #define BOOST_RANGE_DETAIL_ANY_ITERATOR_WRAPPER_HPP_INCLUDED
 
-#include <boost/cast.hpp>
+#include <boost/polymorphic_cast.hpp>
 #include <boost/range/config.hpp>
 #include <boost/range/detail/any_iterator_interface.hpp>
 #include <boost/range/concepts.hpp>


### PR DESCRIPTION
- Instead include `boost/polymorphic_cast.hpp` directly.
- This replaces the dependency of Boost.Range on Boost.NumericConversion with a direct dependency on Boost.Conversion (on which it anyway depends transitively via Boost.Iterator