### PR TITLE
Specialize range_const_iterator_helper for std::span

### DIFF
--- a/include/boost/range/const_iterator.hpp
+++ b/include/boost/range/const_iterator.hpp
@@ -23,6 +23,9 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <cstddef>
 #include <utility>
+#if __cpp_lib_span >= 201902L
+#   include <span>
+#endif
 
 namespace boost
 {
@@ -59,6 +62,20 @@ struct range_const_iterator_helper< T[sz] >
 {
     typedef const T* type;
 };
+
+//////////////////////////////////////////////////////////////////////////
+// span
+//////////////////////////////////////////////////////////////////////////
+
+#if __cpp_lib_span >= 201902L
+
+template< typename T, std::size_t sz >
+struct range_const_iterator_helper< std::span<T, sz> >
+{
+    typedef typename std::span<T const, sz>::iterator type;
+};
+
+#endif
 
     } // namespace range_detail
 


### PR DESCRIPTION
std::span [does not have const_iterator member type](https://cplusplus.github.io/LWG/lwg-defects.html#3320), so this fails:

    #include <span>
    #include <boost/range/iterator.hpp>
    boost::range_iterator<std::span<int> const>::type i;
    //                                           ^~~~
    // error: 'type' in 'struct boost::range_iterator<const std::span<int> >' does not name a type

[Demo](https://godbolt.org/z/3sb6xr).

I'm using 201902 as the feature test value on the basis that an implementation may have applied that change but not yet applied P1976R2 which updates the feature test to 202002L.