### PR TITLE
Allow using C++20 ranges with Boost.Range

### DIFF
--- a/include/boost/range/const_iterator.hpp
+++ b/include/boost/range/const_iterator.hpp
@@ -23,6 +23,9 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <cstddef>
 #include <utility>
+#if __cpp_lib_ranges >= 201911L
+#   include <ranges>
+#endif
 
 namespace boost
 {
@@ -39,6 +42,20 @@ template< typename C >
 struct range_const_iterator_helper
         : extract_const_iterator<C>
 {};
+
+//////////////////////////////////////////////////////////////////////////
+// common_range
+//////////////////////////////////////////////////////////////////////////
+
+#if __cpp_lib_ranges >= 201902L
+
+template< std::ranges::common_range C >
+struct range_const_iterator_helper< C >
+{
+    typedef std::ranges::iterator_t< C const > type;
+};
+
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 // pair

--- a/include/boost/range/mutable_iterator.hpp
+++ b/include/boost/range/mutable_iterator.hpp
@@ -23,6 +23,9 @@
 #include <boost/iterator/iterator_traits.hpp>
 #include <cstddef>
 #include <utility>
+#if __cpp_lib_ranges >= 201902L
+#   include <ranges>
+#endif
 
 namespace boost
 {
@@ -41,6 +44,20 @@ struct range_mutable_iterator
         : range_detail::extract_iterator<
             BOOST_DEDUCED_TYPENAME remove_reference<C>::type>
 {};
+
+//////////////////////////////////////////////////////////////////////////
+// common_range
+//////////////////////////////////////////////////////////////////////////
+
+#if __cpp_lib_ranges >= 201902L
+
+template< std::ranges::common_range C >
+struct range_mutable_iterator< C >
+{
+    typedef std::ranges::iterator_t< C > type;
+};
+
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 // pair


### PR DESCRIPTION
e.g.:

    std::views::iota(99) | std::views::common | boost::adaptors::indexed(42)

obviously this won't work with heterogeneous ranges, so i've constrained to common ranges.

Demo: https://godbolt.org/z/n53jWz