### PR TITLE
Fix -Wdeprecated-copy

### DIFF
--- a/include/boost/range/sub_range.hpp
+++ b/include/boost/range/sub_range.hpp
@@ -184,9 +184,10 @@ public:
         sub_range(const sub_range& r)
             : base(impl::adl_begin(const_cast<base&>(static_cast<const base&>(r))),
                    impl::adl_end(const_cast<base&>(static_cast<const base&>(r))))
-        { }  
+        { }
+#else
+        sub_range(const sub_range& r) = default;
 #endif
-
         template< class ForwardRange2 >
         sub_range(
             ForwardRange2& r,


### PR DESCRIPTION
Modern C++ demands explicit defauling of copy ctor when custom copy assignment operator is defined.