### PR TITLE
refactor: use core/enable_if.hpp over utility.hpp

### DIFF
--- a/include/boost/range/size.hpp
+++ b/include/boost/range/size.hpp
@@ -22,7 +22,7 @@
 #include <boost/range/detail/has_member_size.hpp>
 #include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/utility.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace boost
 {


### PR DESCRIPTION
The later is deprecated. From utility.hpp:
> // Use of this header is discouraged and it will be deprecated.
> // Please include one or more of the headers below instead.