### PR TITLE
Explicitly default copy assignment operator

### DIFF
--- a/include/boost/range/sub_range.hpp
+++ b/include/boost/range/sub_range.hpp
@@ -185,6 +185,8 @@ public:
             : base(impl::adl_begin(const_cast<base&>(static_cast<const base&>(r))),
                    impl::adl_end(const_cast<base&>(static_cast<const base&>(r))))
         { }  
+#elif !(defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) || defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS))
+        sub_range(const sub_range& r) = default;
 #endif
 
         template< class ForwardRange2 >


### PR DESCRIPTION
The compiler-generated copy assignment operator is deprecated since C++11 on classes with user-declared copy constructor.

This change allows clean compilation with the -Wdeprecated-copy/-Wdeprecated-copy-with-user-provided-ctor flag.