### PR TITLE
fixed compilation error in mfc.hpp with VS2022, MSVC 14.3

### DIFF
--- a/include/boost/range/mfc.hpp
+++ b/include/boost/range/mfc.hpp
@@ -292,11 +292,8 @@ namespace boost { namespace range_detail_microsoft {
         struct meta
         {
             typedef list_iterator<X, ::CObject *> mutable_iterator;
-    #if !defined(BOOST_RANGE_MFC_CONST_COL_RETURNS_NON_REF)
-            typedef list_iterator<X const, ::CObject const *> const_iterator;
-    #else
+            // const CObList and const CPtrList both return a value (and probably always will)
             typedef list_iterator<X const, ::CObject const * const, ::CObject const * const> const_iterator;
-    #endif
         };
     };
 
@@ -309,11 +306,8 @@ namespace boost { namespace range_detail_microsoft {
         struct meta
         {
             typedef list_iterator<X, void *> mutable_iterator;
-    #if !defined(BOOST_RANGE_MFC_CONST_COL_RETURNS_NON_REF)
-            typedef list_iterator<X const, void const *> const_iterator;
-    #else
+            // const CObList and const CPtrList both return a value (and probably always will)
             typedef list_iterator<X const, void const * const, void const * const> const_iterator;
-    #endif
         };
     };
 


### PR DESCRIPTION
`const CObList` and `const CPtrList` still return a value from `GetHead`, `GetTail` and `GetAt`. MSVC 14.2 didn't complain about it, but 14.3 does so.

It would be great if this fix could make it into 1.82, since the only "non-intrusive" way to fix this as user would be defining BOOST_RANGE_MFC_CONST_COL_RETURNS_NON_REF which affects also other collections.