### PR TITLE
Fix for docs: https://github.com/boostorg/range/issues/145

### DIFF
--- a/doc/reference/algorithm_ext/is_sorted.qbk
+++ b/doc/reference/algorithm_ext/is_sorted.qbk
@@ -19,9 +19,11 @@ bool is_sorted(const SinglePassRange& rng, BinaryPredicate pred);
 
 `is_sorted` determines if a range is sorted.
 For the non-predicate version the return value is `true` if and only if for
-each adjacent elements `[x,y]` the expression `x < y` is `true`.
+each adjacent elements `[x, y]` the expression `y < x` is `false` (i.e.,
+`x <= y`), or if the number of elements is zero or one.
 For the predicate version the return value is `true` is and only if for each
-adjacent elements `[x,y]` the expression `pred(x,y)` is `true`.
+adjacent elements `[x, y]` the expression `pred(y, x)` is `false`, or if the
+number of elements is zero or one.
 
 [heading Definition]
 


### PR DESCRIPTION
Fix to allow equality not just `<`.