### PR TITLE
Fix range filtered/filter return type in documentation

### DIFF
--- a/doc/reference/adaptors/filtered.qbk
+++ b/doc/reference/adaptors/filtered.qbk
@@ -15,7 +15,7 @@
 * [*Postcondition:] For all elements `[x]` in the returned range, `pred(x)` is `true`.
 * [*Throws:] Whatever the copy constructor of `pred` might throw.
 * [*Range Category:] __singlepass_range__
-* [*Range Return Type:] `boost::filtered_range<decltype(rng)>`
+* [*Range Return Type:] `boost::filtered_range<decltype(pred), decltype(rng)>`
 * [*Returned Range Category:] The minimum of the range category of `rng` and __bidirectional_range__
 
 [section:filtered_example filtered example]


### PR DESCRIPTION
I was struggling to find the return type of range filtered/filter.

Here is a small working example (based from your documentation):
```cpp
#include <boost/range/adaptor/filtered.hpp>
#include <boost/range/algorithm/copy.hpp>
#include <boost/assign.hpp>
#include <iterator>
#include <iostream>
#include <vector>

struct is_even
{
    bool operator()( int x ) const { return x % 2 == 0; }
};

int main(int argc, const char* argv[])
{
    std::vector<int> input {1,2,3,4,5,6,7,8,9};
    
    boost::filtered_range<decltype(is_even()), decltype(input)> f_range = boost::adaptors::filter(input, is_even());
    boost::copy(f_range, std::ostream_iterator<int>(std::cout, ","));

    return 0;
}
```