### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/range
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -7,23 +7,23 @@ import project ;
 
 project /boost/range
     : common-requirements
-        <source>/boost/array//boost_array
-        <source>/boost/assert//boost_assert
-        <source>/boost/concept_check//boost_concept_check
-        <source>/boost/config//boost_config
-        <source>/boost/container_hash//boost_container_hash
-        <source>/boost/conversion//boost_conversion
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/optional//boost_optional
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/regex//boost_regex
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/tuple//boost_tuple
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/array//boost_array
+        <library>/boost/assert//boost_assert
+        <library>/boost/concept_check//boost_concept_check
+        <library>/boost/config//boost_config
+        <library>/boost/container_hash//boost_container_hash
+        <library>/boost/conversion//boost_conversion
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/optional//boost_optional
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/regex//boost_regex
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/tuple//boost_tuple
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,36 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/range
+    : common-requirements
+        <source>/boost/array//boost_array
+        <source>/boost/assert//boost_assert
+        <source>/boost/concept_check//boost_concept_check
+        <source>/boost/config//boost_config
+        <source>/boost/container_hash//boost_container_hash
+        <source>/boost/conversion//boost_conversion
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/optional//boost_optional
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/regex//boost_regex
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/tuple//boost_tuple
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_range ]
+    [ alias all : boost_range test ]
+    ;
+
+call-if : boost-library range
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/range

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -14,19 +14,23 @@ import testing ;
 
 project
     : requirements
-        <library>/boost/test//boost_unit_test_framework/
-        <library>/boost/regex//boost_regex/
+        <source>/boost/assign//boost_assign
+        <source>/boost/foreach//boost_foreach
+        <source>/boost/lambda//boost_lambda
+        <source>/boost/regex//boost_regex/<link>static
+        <source>/boost/test//boost_unit_test_framework
+        <source>/boost/variant//boost_variant
         <link>static
         <threading>multi
     ;
 
-rule range-test ( name : includes * )
+rule range-test ( name : requirements * )
 {
     return [
-        run $(name).cpp /boost/test//boost_unit_test_framework /boost/regex//boost_regex/<link>static
+        run $(name).cpp
         :
         :
-        : <toolset>gcc:<cxxflags>"-Wall -Wunused "
+        : <toolset>gcc:<cxxflags>"-Wall -Wunused " $(requirements)
         ] ;
 }
 
@@ -67,7 +71,7 @@ test-suite range :
     [ range-test adaptor_test/sliced ]
     [ range-test adaptor_test/strided ]
     [ range-test adaptor_test/strided2 ]
-    [ range-test adaptor_test/ticket_6742_transformed_c4789_warning ]
+    [ range-test adaptor_test/ticket_6742_transformed_c4789_warning : <source>/boost/phoenix//boost_phoenix ]
     [ range-test adaptor_test/ticket_8676_sliced_transformed ]
     [ range-test adaptor_test/ticket_9519_strided_reversed ]
     [ range-test adaptor_test/tokenized ]


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854
- https://github.com/boostorg/auto_index/pull/7
- https://github.com/boostorg/bcp/pull/20
- https://github.com/boostorg/boost_install/pull/69
- https://github.com/boostorg/boost/pull/890
- https://github.com/boostorg/boostbook/pull/25
- https://github.com/boostorg/boostdep/pull/21
- https://github.com/boostorg/docca/pull/143
- https://github.com/boostorg/inspect/pull/19
- https://github.com/boostorg/quickbook/pull/25

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.