### PR TITLE
Fix missing and unneeded Boost.MPL includes

### DIFF
--- a/include/boost/range/algorithm/for_each.hpp
+++ b/include/boost/range/algorithm/for_each.hpp
@@ -13,8 +13,8 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/concepts.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/ref.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/core/ref.hpp>
 #include <algorithm>
 
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1600)

--- a/include/boost/range/any_range.hpp
+++ b/include/boost/range/any_range.hpp
@@ -10,6 +10,8 @@
 #define BOOST_RANGE_ANY_RANGE_HPP_INCLUDED
 
 #include <boost/config.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/iterator/iterator_facade.hpp>

--- a/include/boost/range/concepts.hpp
+++ b/include/boost/range/concepts.hpp
@@ -23,6 +23,7 @@
 #include <boost/range/iterator.hpp>
 #include <boost/range/value_type.hpp>
 #include <boost/range/detail/misc_concept.hpp>
+#include <boost/mpl/assert.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/is_integral.hpp>
 

--- a/include/boost/range/detail/any_iterator.hpp
+++ b/include/boost/range/detail/any_iterator.hpp
@@ -13,6 +13,7 @@
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/not.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_reference.hpp>
@@ -20,7 +21,7 @@
 #include <boost/range/detail/any_iterator_buffer.hpp>
 #include <boost/range/detail/any_iterator_interface.hpp>
 #include <boost/range/detail/any_iterator_wrapper.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace boost
 {

--- a/include/boost/range/detail/any_iterator_interface.hpp
+++ b/include/boost/range/detail/any_iterator_interface.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_RANGE_DETAIL_ANY_ITERATOR_INTERFACE_HPP_INCLUDED
 #define BOOST_RANGE_DETAIL_ANY_ITERATOR_INTERFACE_HPP_INCLUDED
 
+#include <boost/mpl/if.hpp>
 #include <boost/range/detail/any_iterator_buffer.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/type_traits/is_convertible.hpp>

--- a/include/boost/range/detail/collection_traits_detail.hpp
+++ b/include/boost/range/detail/collection_traits_detail.hpp
@@ -20,10 +20,7 @@
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits/remove_cv.hpp>
-#include <boost/mpl/eval_if.hpp>
-#include <boost/mpl/identity.hpp>
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/fold.hpp>
+#include <boost/mpl/if.hpp>
 
 // Container traits implementation ---------------------------------------------------------
 

--- a/include/boost/range/detail/has_member_size.hpp
+++ b/include/boost/range/detail/has_member_size.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/type_traits/is_class.hpp>
 #include <boost/type_traits/is_member_function_pointer.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/cstdint.hpp>

--- a/include/boost/range/detail/join_iterator.hpp
+++ b/include/boost/range/detail/join_iterator.hpp
@@ -19,6 +19,7 @@
 
 #include <iterator>
 #include <boost/assert.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/range/begin.hpp>

--- a/include/boost/range/detail/microsoft.hpp
+++ b/include/boost/range/detail/microsoft.hpp
@@ -56,8 +56,8 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_cv.hpp>
-#include <boost/utility/addressof.hpp>
-#include <boost/utility/enable_if.hpp> // disable_if
+#include <boost/core/addressof.hpp>
+#include <boost/core/enable_if.hpp> // disable_if
 #include <boost/next_prior.hpp>
 
 #if !defined(BOOST_RANGE_DETAIL_MICROSOFT_RANGE_VERSION_1)

--- a/include/boost/range/detail/msvc_has_iterator_workaround.hpp
+++ b/include/boost/range/detail/msvc_has_iterator_workaround.hpp
@@ -20,6 +20,8 @@
 #endif
 
 #if BOOST_WORKAROUND(BOOST_MSVC, <= 1600)
+#include <boost/mpl/bool.hpp>
+
 namespace boost
 {
 namespace cb_details

--- a/include/boost/range/has_range_iterator.hpp
+++ b/include/boost/range/has_range_iterator.hpp
@@ -18,7 +18,7 @@
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/range/iterator.hpp>
 #include <boost/type_traits/remove_reference.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace boost
 {

--- a/include/boost/range/iterator.hpp
+++ b/include/boost/range/iterator.hpp
@@ -22,6 +22,7 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/if.hpp>
 
 namespace boost
 {

--- a/include/boost/range/iterator_range_core.hpp
+++ b/include/boost/range/iterator_range_core.hpp
@@ -26,8 +26,11 @@
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/not.hpp>
+#include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>
+#include <boost/mpl/identity.hpp>
 #include <boost/type_traits/is_abstract.hpp>
 #include <boost/type_traits/is_array.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
@@ -41,7 +44,7 @@
 #include <boost/range/has_range_iterator.hpp>
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/range/detail/safe_bool.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/next_prior.hpp>
 #include <iterator>
 #include <algorithm>

--- a/include/boost/range/mfc.hpp
+++ b/include/boost/range/mfc.hpp
@@ -90,7 +90,7 @@ class CTypedPtrMap;
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
-#include <boost/utility/addressof.hpp>
+#include <boost/core/addressof.hpp>
 #include <afx.h> // legacy CString
 #include <afxcoll.h> // CXXXArray, CXXXList, CMapXXXToXXX
 #include <tchar.h>

--- a/include/boost/range/size_type.hpp
+++ b/include/boost/range/size_type.hpp
@@ -20,7 +20,7 @@
 #include <boost/range/concepts.hpp>
 #include <boost/range/has_range_iterator.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <cstddef>

--- a/include/boost/range/sub_range.hpp
+++ b/include/boost/range/sub_range.hpp
@@ -27,6 +27,8 @@
 #include <boost/range/reference.hpp>
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/assert.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 


### PR DESCRIPTION
This adds missing Boost.MPL includes, as well as removes includes that are not used. It also updates some of the Boost.Core includes to use up to date headers instead of the deprecated forwarding stubs.
