### PR TITLE
Add a dedicated include for enable_if_convertible

### DIFF
--- a/include/boost/range/adaptor/strided.hpp
+++ b/include/boost/range/adaptor/strided.hpp
@@ -14,6 +14,7 @@
 #include <boost/range/adaptor/argument_fwd.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/iterator/iterator_facade.hpp>
+#include <boost/iterator/enable_if_convertible.hpp>
 #include <iterator>
 
 namespace boost
@@ -66,7 +67,7 @@ namespace boost
             template<class OtherIterator>
             strided_iterator(
                 const strided_iterator<OtherIterator, Category>& other,
-                typename enable_if_convertible<
+                typename iterators::enable_if_convertible<
                     OtherIterator,
                     base_iterator
                 >::type* = 0
@@ -110,7 +111,7 @@ namespace boost
             template<class OtherIterator>
             bool equal(
                 const strided_iterator<OtherIterator, Category>& other,
-                typename enable_if_convertible<
+                typename iterators::enable_if_convertible<
                     OtherIterator,
                     base_iterator
                 >::type* = 0) const
@@ -177,7 +178,7 @@ namespace boost
                     OtherIterator,
                     bidirectional_traversal_tag
                 >& other,
-                typename enable_if_convertible<
+                typename iterators::enable_if_convertible<
                     OtherIterator,
                     base_iterator
                 >::type* = 0
@@ -239,7 +240,7 @@ namespace boost
                     OtherIterator,
                     bidirectional_traversal_tag
                 >& other,
-                typename enable_if_convertible<
+                typename iterators::enable_if_convertible<
                     OtherIterator,
                     base_iterator
                 >::type* = 0) const
@@ -308,7 +309,7 @@ namespace boost
                     OtherIterator,
                     random_access_traversal_tag
                 >& other,
-                typename enable_if_convertible<
+                typename iterators::enable_if_convertible<
                     OtherIterator,
                     base_iterator
                 >::type* = 0
@@ -372,7 +373,7 @@ namespace boost
                     OtherIterator,
                     random_access_traversal_tag
                 >& other,
-                typename enable_if_convertible<
+                typename iterators::enable_if_convertible<
                             OtherIterator, base_iterator>::type* = 0) const
             {
                 BOOST_ASSERT((other.m_index - m_index) % m_stride == difference_type());
@@ -385,7 +386,7 @@ namespace boost
                     OtherIterator,
                     random_access_traversal_tag
                 >& other,
-                typename enable_if_convertible<
+                typename iterators::enable_if_convertible<
                             OtherIterator, base_iterator>::type* = 0) const
             {
                 return m_index == other.m_index;


### PR DESCRIPTION
`enable_if_convertible` is now defined in a separate header in Boost.Iterator. Also qualify iterators namespace for `enable_if_convertible`.