### PR TITLE
Add include for add_const

### DIFF
--- a/include/boost/range/detail/any_iterator_interface.hpp
+++ b/include/boost/range/detail/any_iterator_interface.hpp
@@ -13,6 +13,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/range/detail/any_iterator_buffer.hpp>
 #include <boost/iterator/iterator_categories.hpp>
+#include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/remove_const.hpp>


### PR DESCRIPTION
While testing 1.88.0.beta1 in Homebrew (https://github.com/Homebrew/homebrew-core/pull/217231), I saw a build error for `ncmpcpp`:
```
  In file included from ./curses/menu.h:25:
  In file included from /opt/homebrew/include/boost/range/detail/any_iterator.hpp:22:
  /opt/homebrew/include/boost/range/detail/any_iterator_interface.hpp:30:26: error: no template named 'add_const'; did you mean 'std::add_const'?
     30 |                 typename add_const<
        |                          ^
```

From glance, it looks like Boost `add_const` is wanted for
https://github.com/boostorg/range/blob/a18dbf5d3384444e23e3c65915c1f69981d026bd/include/boost/range/detail/any_iterator_interface.hpp#L30