### PR TITLE
[Doxygen] Name the argument in structured comments

### DIFF
--- a/include/boost/range/iterator_range_core.hpp
+++ b/include/boost/range/iterator_range_core.hpp
@@ -836,7 +836,7 @@ public:
             Construct a new sequence of the specified type from the elements
             in the given range
 
-            \param Range An input range
+            \param r Range An input range
             \return New sequence
         */
         template< typename SeqT, typename Range >


### PR DESCRIPTION
documentation validator tool complains about missing argument name.