### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(boost_range
     Boost::optional
     Boost::preprocessor
     Boost::regex
-    Boost::static_assert
     Boost::tuple
     Boost::type_traits
     Boost::utility

--- a/build.jam
+++ b/build.jam
@@ -19,7 +19,6 @@ constant boost_dependencies :
     /boost/optional//boost_optional
     /boost/preprocessor//boost_preprocessor
     /boost/regex//boost_regex
-    /boost/static_assert//boost_static_assert
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits
     /boost/utility//boost_utility ;


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.